### PR TITLE
Fix penalty

### DIFF
--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3460,6 +3460,16 @@ PenaltyRef::tackleTaken( const Player & tackler,
         return;
     }
 
+    const PlayMode pm = M_stadium.playmode();
+
+    if ( pm == PM_PenaltyMiss_Left
+         || pm == PM_PenaltyScore_Left
+         || pm == PM_PenaltyMiss_Right
+         || pm == PM_PenaltyScore_Right )
+    {
+	    return;
+    }
+
     bool detect_charge = false;
     bool detect_yellow = false;
     bool detect_red = false;

--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3312,7 +3312,7 @@ PenaltyRef::ballCaught( const Player & catcher )
                       << -M_cur_pen_taker
                       << std::endl;
             // taker team's goalie catches the ball
-            penalty_foul( (Side)( -M_cur_pen_taker ) );
+            penalty_foul( (Side)( M_cur_pen_taker ) );
         }
         else if ( ! inPenaltyArea( M_pen_side, M_stadium.ball().pos() ) )
         {


### PR DESCRIPTION
I found two bugs in the penalty shootings mechanism, and I fixed them.
The first bug permitted to assign a foul to a team after a penalty was terminated (play mode = PenaltyMiss_x or PenaltyScore_x) but before a new penalty was started (hence, in an irrelevant moment). Because of the penalty_foul() mechanism, this could lead either to an additional wrong penalty score assigned to the penalty taker (if the defending goalkeeper was committing the foul), or, as it happened in an experiment, it could lead to a wrong increase in the number of total penalties taken (if the penalty taker was committing the foul), that in turn could mess with the conditions to terminate a game, as checked inside penalty_check_score(). (Attachment: the log of a game with the game ending instead of waiting for the second team to play its due penalty. At tick 8091 there is a wrong foul assignment because of a tackle during a Penalty_Miss_Left play mode).
The second bug was assigning a foul to the wrong team in case the goalkeeper of the penalty taker team was catching the ball instead of staying out of the game. (I suppose this situation anyway would not happen if the client programs are well-written and stop the goalkeeper that is not involved in the penalty).
[robocup_penalty_error_game.zip](https://github.com/rcsoccersim/rcssserver/files/2943035/robocup_penalty_error_game.zip)
