### PR TITLE
Add a fixed teamname feature

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -935,7 +935,7 @@ AudioSenderOnlineCoachv1::sendPlayerAudio( const Player & player,
     {
         serializer().serializePlayerAudio( transport(),
                                            M_stadium.time(),
-                                           player.name(),
+                                           ( listener().side() == player.side() ? player.name() : player.fixedName() ),
                                            msg );
         transport() << std::ends << std::flush;
     }
@@ -949,7 +949,7 @@ AudioSenderOnlineCoachv7::sendPlayerAudio( const Player & player,
     {
         serializer().serializePlayerAudio( transport(),
                                            M_stadium.time(),
-                                           player.shortName(),
+                                           ( listener().side() == player.side() ? player.shortName() : player.fixedShortName() ),
                                            msg );
         transport() << std::ends << std::flush;
     }

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -979,7 +979,7 @@ RegHolder vp12 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlaye
 RegHolder vp13 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlayerv8 >, 13 );
 RegHolder vp14 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlayerv8 >, 14 );
 RegHolder vp15 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlayerv8 >, 15 );
-//RegHolder vp16 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlayerv8 >, 16 );
+RegHolder vp16 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlayerv8 >, 16 );
 
 template< typename Sender >
 AudioSender::Ptr
@@ -1003,7 +1003,7 @@ RegHolder vc12 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv
 RegHolder vc13 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv7 >, 13 );
 RegHolder vc14 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv7 >, 14 );
 RegHolder vc15 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv7 >, 15 );
-//RegHolder vc16 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv7 >, 16 );
+RegHolder vc16 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv7 >, 16 );
 
 template< typename Sender >
 AudioSender::Ptr
@@ -1027,6 +1027,6 @@ RegHolder voc12 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSende
 RegHolder voc13 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSenderOnlineCoachv7 >, 13 );
 RegHolder voc14 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSenderOnlineCoachv7 >, 14 );
 RegHolder voc15 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSenderOnlineCoachv7 >, 15 );
-//RegHolder voc16 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSenderOnlineCoachv7 >, 16 );
+RegHolder voc16 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSenderOnlineCoachv7 >, 16 );
 }
 }

--- a/src/bodysender.cpp
+++ b/src/bodysender.cpp
@@ -426,7 +426,7 @@ RegHolder vp12 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV
 RegHolder vp13 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV13 >, 13 );
 RegHolder vp14 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV14 >, 14 );
 RegHolder vp15 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV14 >, 15 );
-//RegHolder vp16 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV14 >, 16 );
+RegHolder vp16 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV14 >, 16 );
 }
 
 }

--- a/src/coach.cpp
+++ b/src/coach.cpp
@@ -689,12 +689,20 @@ Coach::team_names()
 
     if ( ! M_stadium.teamLeft().name().empty() )
     {
-        ost << " (team l " << M_stadium.teamLeft().name() << ")";
+        ost << " (team l "
+            << ( side() == RIGHT
+                 ? M_stadium.teamLeft().fixedName()
+                 : M_stadium.teamLeft().name() )
+            << ")";
     }
 
     if ( ! M_stadium.teamRight().name().empty() )
     {
-        ost << " (team r " << M_stadium.teamRight().name() << ")";
+        ost << " (team r "
+            << ( side() == LEFT
+                 ? M_stadium.teamRight().fixedName()
+                 : M_stadium.teamRight().name() )
+            << ")";
     }
 
     ost << ")" << std::endl;

--- a/src/fullstatesender.cpp
+++ b/src/fullstatesender.cpp
@@ -477,7 +477,7 @@ RegHolder vp12 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSen
 RegHolder vp13 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSenderPlayerV13 >, 13 );
 RegHolder vp14 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSenderPlayerV13 >, 14 );
 RegHolder vp15 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSenderPlayerV13 >, 15 );
-//RegHolder vp16 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSenderPlayerV13 >, 16 );
+RegHolder vp16 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSenderPlayerV13 >, 16 );
 }
 
 }

--- a/src/initsendercoach.cpp
+++ b/src/initsendercoach.cpp
@@ -220,7 +220,7 @@ RegHolder vc12 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderO
 RegHolder vc13 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderOfflineCoachV8 >, 13 );
 RegHolder vc14 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderOfflineCoachV8 >, 14 );
 RegHolder vc15 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderOfflineCoachV8 >, 15 );
-//RegHolder vc16 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderOfflineCoachV8 >, 16 );
+RegHolder vc16 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderOfflineCoachV8 >, 16 );
 }
 
 }

--- a/src/initsenderonlinecoach.cpp
+++ b/src/initsenderonlinecoach.cpp
@@ -304,7 +304,7 @@ RegHolder voc12 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderO
 RegHolder voc13 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderOnlineCoachV8 >, 13 );
 RegHolder voc14 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderOnlineCoachV8 >, 14 );
 RegHolder voc15 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderOnlineCoachV8 >, 15 );
-//RegHolder voc16 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderOnlineCoachV8 >, 16 );
+RegHolder voc16 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderOnlineCoachV8 >, 16 );
 }
 
 }

--- a/src/initsenderplayer.cpp
+++ b/src/initsenderplayer.cpp
@@ -283,7 +283,7 @@ RegHolder vp12 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV
 RegHolder vp13 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV8 >, 13 );
 RegHolder vp14 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV8 >, 14 );
 RegHolder vp15 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV8 >, 15 );
-//RegHolder vp16 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV8 >, 16 );
+RegHolder vp16 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV8 >, 16 );
 }
 
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -278,12 +278,19 @@ Player::init( const double ver,
     M_goalie_catch_ban = 0;
     M_goalie_moves_since_catch = 0;
 
+    const std::string fixed_teamname = team()->fixedName();
     {
         char lname[128], sname[128];
         snprintf( lname, 128, PLAYER_NAME_FORMAT, team()->name().c_str(), unum() );
         snprintf( sname, 128, PLAYER_NAME_FORMAT_SHORT, team()->name().c_str(), unum(),
                   isGoalie() ? GOALIE_VISUAL_STRING : "" );
         setName( lname, sname );
+
+        snprintf( lname, 128, PLAYER_NAME_FORMAT, fixed_teamname.c_str(), unum() );
+        snprintf( sname, 128, PLAYER_NAME_FORMAT_SHORT, fixed_teamname.c_str(), unum(),
+                  isGoalie() ? GOALIE_VISUAL_STRING : "" );
+        M_fixed_name = lname;
+        M_fixed_short_name = sname;
     }
 
     char buf[128];
@@ -296,6 +303,13 @@ Player::init( const double ver,
     M_short_name_far = buf;
     snprintf( buf, 128, PLAYER_NAME_TOOFAR_FORMAT_SHORT );
     M_short_name_toofar = buf;
+
+
+    snprintf( buf, 128, PLAYER_NAME_FAR_FORMAT, fixed_teamname.c_str() );
+    M_fixed_name_far = buf;
+    snprintf( buf, 128, PLAYER_NAME_FAR_FORMAT_SHORT, fixed_teamname.c_str() );
+    M_fixed_short_name_far = buf;
+
 
     M_angle_body_committed = SideDirection( side() );
 

--- a/src/player.h
+++ b/src/player.h
@@ -78,6 +78,11 @@ private:
     std::string M_short_name_far;
     std::string M_short_name_toofar;
 
+    std::string M_fixed_name;
+    std::string M_fixed_name_far;
+    std::string M_fixed_short_name;
+    std::string M_fixed_short_name_far;
+
     double M_unum_far_length;
     double M_unum_too_far_length;
     double M_team_far_length;
@@ -238,6 +243,11 @@ public:
     const std::string & nameTooFar() const { return M_name_toofar; }
     const std::string & shortNameFar() const { return M_short_name_far; }
     const std::string & shortNameTooFar() const { return M_short_name_toofar; }
+
+    const std::string & fixedName() const { return M_fixed_name; }
+    const std::string & fixedNameFar() const { return M_fixed_name_far; }
+    const std::string & fixedShortName() const { return M_fixed_short_name; }
+    const std::string & fixedShortNameFar() const { return M_fixed_short_name_far; }
 
     const double & unumFarLength() const { return M_unum_far_length; }
     const double & unumTooFarLength() const { return M_unum_too_far_length; }

--- a/src/serializercoachstdv14.cpp
+++ b/src/serializercoachstdv14.cpp
@@ -136,7 +136,7 @@ SerializerCoachStdv14::create()
 namespace {
 RegHolder v14 = SerializerCoach::factory().autoReg( &SerializerCoachStdv14::create, 14 );
 RegHolder v15 = SerializerCoach::factory().autoReg( &SerializerCoachStdv14::create, 15 );
-//RegHolder v16 = SerializerCoach::factory().autoReg( &SerializerCoachStdv14::create, 16 );
+RegHolder v16 = SerializerCoach::factory().autoReg( &SerializerCoachStdv14::create, 16 );
 }
 
 }

--- a/src/serializercommonstdv8.cpp
+++ b/src/serializercommonstdv8.cpp
@@ -106,7 +106,7 @@ RegHolder v12 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::cre
 RegHolder v13 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::create, 13 );
 RegHolder v14 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::create, 14 );
 RegHolder v15 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::create, 15 );
-//RegHolder v16 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::create, 16 );
+RegHolder v16 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::create, 16 );
 }
 
 }

--- a/src/serializeronlinecoachstdv14.cpp
+++ b/src/serializeronlinecoachstdv14.cpp
@@ -62,7 +62,7 @@ SerializerOnlineCoachStdv14::create()
 namespace {
 RegHolder v14 = SerializerOnlineCoach::factory().autoReg( &SerializerOnlineCoachStdv14::create, 14 );
 RegHolder v15 = SerializerOnlineCoach::factory().autoReg( &SerializerOnlineCoachStdv14::create, 15 );
-//RegHolder v16 = SerializerOnlineCoach::factory().autoReg( &SerializerOnlineCoachStdv14::create, 16 );
+RegHolder v16 = SerializerOnlineCoach::factory().autoReg( &SerializerOnlineCoachStdv14::create, 16 );
 }
 
 }

--- a/src/serializerplayerstdv14.cpp
+++ b/src/serializerplayerstdv14.cpp
@@ -140,7 +140,7 @@ SerializerPlayerStdv14::create()
 namespace {
 RegHolder v14 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv14::create, 14 );
 RegHolder v15 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv14::create, 15 );
-//RegHolder v16 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv14::create, 16 );
+RegHolder v16 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv14::create, 16 );
 }
 
 }

--- a/src/serverparam.cpp
+++ b/src/serverparam.cpp
@@ -89,6 +89,24 @@ lcm( int a,
     return tmp;
 }
 
+
+std::string
+check_teamname_format( std::string name )
+{
+    if ( name.empty() ) return name;
+
+    const std::string available_chars = "+-_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    if ( name.find_first_not_of( available_chars ) != std::string::npos )
+    {
+        return std::string( "" );
+    }
+
+    if ( name.length() > 15 ) name.resize( 15 );
+
+    return name;
+}
+
 }
 
 
@@ -908,8 +926,14 @@ ServerParam::addParams()
               "", 15 );
 
     // v16
-    addParam( "fixed_teamname_l", M_fixed_teamname_l, "", 16 );
-    addParam( "fixed_teamname_r", M_fixed_teamname_r, "", 16 );
+    addParam( "fixed_teamname_l",
+              rcss::conf::makeSetter( this, &ServerParam::setFixedTeamNameLeft ),
+              rcss::conf::makeGetter( M_fixed_teamname_l ),
+              "", 16 );
+    addParam( "fixed_teamname_r",
+              rcss::conf::makeSetter( this, &ServerParam::setFixedTeamNameRight ),
+              rcss::conf::makeGetter( M_fixed_teamname_r ),
+              "", 16 );
 
     // XXX
     // addParam( "random_seed", M_random_seed, "", 999 );
@@ -1098,6 +1122,39 @@ void
 ServerParam::setRedCardProbability( double value )
 {
     M_red_card_probability = std::max( 0.0, std::min( value, 1.0 ) );
+}
+
+
+void
+ServerParam::setFixedTeamNameLeft( std::string name )
+{
+    name = check_teamname_format( name );
+
+    if ( ! M_fixed_teamname_r.empty()
+         && name == M_fixed_teamname_r )
+    {
+        std::cerr << "Could not set server::fixed_teamname_l='" << name
+                  << "'. The same name is already set to server::fixed_teamname_r." << std::endl;
+        return;
+    }
+
+    M_fixed_teamname_l = name;
+}
+
+void
+ServerParam::setFixedTeamNameRight( std::string name )
+{
+    name = check_teamname_format( name );
+
+    if ( ! M_fixed_teamname_l.empty()
+         && name == M_fixed_teamname_l )
+    {
+        std::cerr << "Could not set server::fixed_teamname_r='" << name
+                  << "'. The same name is already assigned to server::fixed_teamname_r." << std::endl;
+        return;
+    }
+
+    M_fixed_teamname_r = name;
 }
 
 void

--- a/src/serverparam.cpp
+++ b/src/serverparam.cpp
@@ -907,6 +907,10 @@ ServerParam::addParams()
               rcss::conf::makeGetter( M_red_card_probability ),
               "", 15 );
 
+    // v16
+    addParam( "fixed_teamname_l", M_fixed_teamname_l, "", 16 );
+    addParam( "fixed_teamname_r", M_fixed_teamname_r, "", 16 );
+
     // XXX
     // addParam( "random_seed", M_random_seed, "", 999 );
     // addParam( "long_kick_power_factor", M_long_kick_power_factor, "", 999 );
@@ -1366,6 +1370,10 @@ ServerParam::setDefaults()
 
     // 15.0.0
     M_red_card_probability = RED_CARD_PROBABILITY;
+
+    // 16.0.0
+    M_fixed_teamname_l = "";
+    M_fixed_teamname_r = "";
 
     // XXX
     M_long_kick_power_factor = LONG_KICK_POWER_FACTOR;

--- a/src/serverparam.cpp
+++ b/src/serverparam.cpp
@@ -365,15 +365,15 @@ const bool ServerParam::GOLDEN_GOAL = false; // [15.0.0] true -> false
 // 15.0.0
 const double ServerParam::RED_CARD_PROBABILITY = 0.0;
 
-// XXX
-const double ServerParam::LONG_KICK_POWER_FACTOR = 2.0;
-const int ServerParam::LONG_KICK_DELAY = 2;
-
 // 16.0.0
 const int ServerParam::ILLEGAL_DEFENSE_DURATION = 20;
 const int ServerParam::ILLEGAL_DEFENSE_NUMBER = 0;
 const double ServerParam::ILLEGAL_DEFENSE_DIST_X = 16.5;
 const double ServerParam::ILLEGAL_DEFENSE_WIDTH = 40.32;
+
+// XXX
+const double ServerParam::LONG_KICK_POWER_FACTOR = 2.0;
+const int ServerParam::LONG_KICK_DELAY = 2;
 
 ServerParam &
 ServerParam::instance()
@@ -931,6 +931,10 @@ ServerParam::addParams()
               "", 15 );
 
     // v16
+    addParam( "illegal_defense_duration", M_illegal_defense_duration, "", 16);
+    addParam( "illegal_defense_number", M_illegal_defense_number, "if be 0, illegal defense rule will be disable", 16);
+    addParam( "illegal_defense_dist_x", M_illegal_defense_dist_x, "", 16);
+    addParam( "illegal_defense_width", M_illegal_defense_width, "", 16);
     addParam( "fixed_teamname_l",
               rcss::conf::makeSetter( this, &ServerParam::setFixedTeamNameLeft ),
               rcss::conf::makeGetter( M_fixed_teamname_l ),
@@ -945,11 +949,6 @@ ServerParam::addParams()
     // addParam( "long_kick_power_factor", M_long_kick_power_factor, "", 999 );
     // addParam( "long_kick_delay", M_long_kick_delay, "", 999 );
 
-    // v16
-    addParam( "illegal_defense_duration", M_illegal_defense_duration, "", 16);
-    addParam( "illegal_defense_number", M_illegal_defense_number, "if be 0, illegal defense rule will be disable", 16);
-    addParam( "illegal_defense_dist_x", M_illegal_defense_dist_x, "", 16);
-    addParam( "illegal_defense_width", M_illegal_defense_width, "", 16);
 
 }
 
@@ -1441,18 +1440,16 @@ ServerParam::setDefaults()
     M_red_card_probability = RED_CARD_PROBABILITY;
 
     // 16.0.0
+    M_illegal_defense_duration = ILLEGAL_DEFENSE_DURATION;
+    M_illegal_defense_number = ILLEGAL_DEFENSE_NUMBER;
+    M_illegal_defense_dist_x = ILLEGAL_DEFENSE_DIST_X;
+    M_illegal_defense_width = ILLEGAL_DEFENSE_WIDTH;
     M_fixed_teamname_l = "";
     M_fixed_teamname_r = "";
 
     // XXX
     M_long_kick_power_factor = LONG_KICK_POWER_FACTOR;
     M_long_kick_delay = LONG_KICK_DELAY;
-
-    // 16.0.0
-    M_illegal_defense_duration = ILLEGAL_DEFENSE_DURATION;
-    M_illegal_defense_number = ILLEGAL_DEFENSE_NUMBER;
-    M_illegal_defense_dist_x = ILLEGAL_DEFENSE_DIST_X;
-    M_illegal_defense_width = ILLEGAL_DEFENSE_WIDTH;
 
     setHalfTime( HALF_TIME );
     setExtraHalfTime( EXTRA_HALF_TIME );

--- a/src/serverparam.h
+++ b/src/serverparam.h
@@ -604,6 +604,10 @@ private:
     // 15.0.0
     double M_red_card_probability;
 
+    // 16.0.0
+    std::string M_fixed_teamname_l;
+    std::string M_fixed_teamname_r;
+
     // XXX
     double M_long_kick_power_factor;
     int M_long_kick_delay;
@@ -945,6 +949,10 @@ public:
 
     // v15
     double redCardProbability() const { return M_red_card_probability; }
+
+    // v16
+    const std::string & fixedTeamNameLeft() const { return M_fixed_teamname_l; }
+    const std::string & fixedTeamNameRight() const { return M_fixed_teamname_r; }
 
     // XXX
     double longKickPowerFactor() const { return M_long_kick_power_factor; }

--- a/src/serverparam.h
+++ b/src/serverparam.h
@@ -649,6 +649,9 @@ private:
     void setFoulDetectProbability( double value );
     void setRedCardProbability( double value );
 
+    void setFixedTeamNameLeft( std::string name );
+    void setFixedTeamNameRight( std::string name );
+
     void setSlowDownFactor();
 
 public:

--- a/src/serverparam.h
+++ b/src/serverparam.h
@@ -610,18 +610,16 @@ private:
     double M_red_card_probability;
 
     // 16.0.0
+    int M_illegal_defense_duration;
+    int M_illegal_defense_number;
+    double M_illegal_defense_dist_x;
+    double M_illegal_defense_width;
     std::string M_fixed_teamname_l;
     std::string M_fixed_teamname_r;
 
     // XXX
     double M_long_kick_power_factor;
     int M_long_kick_delay;
-
-    // 16.0.0
-    int M_illegal_defense_duration;
-    int M_illegal_defense_number;
-    double M_illegal_defense_dist_x;
-    double M_illegal_defense_width;
 
 private:
 
@@ -965,19 +963,17 @@ public:
     double redCardProbability() const { return M_red_card_probability; }
 
     // v16
+    bool useIllegalDefense() const { return M_illegal_defense_number != 0; }
+    int illegalDefenseDuration() const { return M_illegal_defense_duration; }
+    int illegalDefenseNumber() const { return M_illegal_defense_number; }
+    double illegalDefenseDistX() const { return M_illegal_defense_dist_x; }
+    double illegalDefenseWidth() const { return M_illegal_defense_width; }
     const std::string & fixedTeamNameLeft() const { return M_fixed_teamname_l; }
     const std::string & fixedTeamNameRight() const { return M_fixed_teamname_r; }
 
     // XXX
     double longKickPowerFactor() const { return M_long_kick_power_factor; }
     int longKickDelay() const { return M_long_kick_delay; }
-
-    // v16
-    bool useIllegalDefense() const { return M_illegal_defense_number != 0; }
-    int illegalDefenseDuration() const { return M_illegal_defense_duration; }
-    int illegalDefenseNumber() const { return M_illegal_defense_number; }
-    double illegalDefenseDistX() const { return M_illegal_defense_dist_x; }
-    double illegalDefenseWidth() const { return M_illegal_defense_width; }
 
 };
 

--- a/src/stadium.cpp
+++ b/src/stadium.cpp
@@ -607,6 +607,13 @@ Stadium::initPlayer( const char * teamname,
 {
     Team * team = static_cast< Team * >( 0 );
 
+    if ( ServerParam::instance().fixedTeamNameLeft() == teamname
+         || ServerParam::instance().fixedTeamNameRight() == teamname )
+    {
+        sendToPlayer( "(error conflict_with_fixed_teamname)", addr );
+        return static_cast< Player * >( 0 );
+    }
+
     if ( M_team_l->name().empty() )
     {
         team = M_team_l;

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -259,6 +259,23 @@ Team::assignPlayerTypes()
 //     std::cout << std::endl;
 }
 
+std::string
+Team::fixedName() const
+{
+    if ( side() == LEFT
+         && ! ServerParam::instance().fixedTeamNameLeft().empty() )
+    {
+        return ServerParam::instance().fixedTeamNameLeft();
+    }
+    else if ( side() == RIGHT
+              && ! ServerParam::instance().fixedTeamNameRight().empty() )
+    {
+        return ServerParam::instance().fixedTeamNameRight();
+    }
+
+    return M_name;
+}
+
 int
 Team::ptypeCount( const int player_type ) const
 {

--- a/src/team.h
+++ b/src/team.h
@@ -99,6 +99,7 @@ public:
       {
           return M_name;
       }
+    std::string fixedName() const;
 
     bool enabled() const
       {

--- a/src/visualsendercoach.cpp
+++ b/src/visualsendercoach.cpp
@@ -359,7 +359,7 @@ RegHolder vc12 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoac
 RegHolder vc13 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoachV13 >, 13 );
 RegHolder vc14 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoachV13 >, 14 );
 RegHolder vc15 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoachV13 >, 15 );
-//RegHolder vc16 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoachV13 >, 16 );
+RegHolder vc16 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoachV13 >, 16 );
 }
 
 }

--- a/src/visualsendercoach.cpp
+++ b/src/visualsendercoach.cpp
@@ -169,7 +169,7 @@ void
 VisualSenderCoachV1::serializePlayer( const Player & player )
 {
     serializer().serializeVisualObject( transport(),
-                                        calcName( player ),
+                                        calcPlayerName( player ),
                                         player.pos(),
                                         player.vel(),
                                         rad2Deg( player.angleBodyCommitted() ),
@@ -180,6 +180,15 @@ void
 VisualSenderCoachV1::serializePlayerLook( const Player & player )
 {
     serializePlayer( player );
+}
+
+const std::string &
+VisualSenderCoachV1::calcPlayerName( const Player & obj ) const
+{
+    return self().side() == obj.side()
+        || self().side() == NEUTRAL
+        ? obj.name()
+        : obj.fixedName();
 }
 
 /*!
@@ -201,6 +210,15 @@ VisualSenderCoachV7::VisualSenderCoachV7( const Params & params )
 VisualSenderCoachV7::~VisualSenderCoachV7()
 {
 
+}
+
+const std::string &
+VisualSenderCoachV7::calcPlayerName( const Player & obj ) const
+{
+    return self().side() == obj.side()
+        || self().side() == NEUTRAL
+        ? obj.shortName()
+        : obj.fixedShortName();
 }
 
 /*!
@@ -248,7 +266,7 @@ VisualSenderCoachV8::serializePlayer( const Player & player )
     if ( player.arm().isPointing() )
     {
         serializer().serializeVisualObject( transport(),
-                                            calcName( player ),
+                                            calcPlayerName( player ),
                                             player.pos(),
                                             player.vel(),
                                             rad2Deg( player.angleBodyCommitted() ),
@@ -259,7 +277,7 @@ VisualSenderCoachV8::serializePlayer( const Player & player )
     else
     {
         serializer().serializeVisualObject( transport(),
-                                            calcName( player ),
+                                            calcPlayerName( player ),
                                             player.pos(),
                                             player.vel(),
                                             rad2Deg( player.angleBodyCommitted() ),
@@ -303,7 +321,7 @@ VisualSenderCoachV13::serializePlayer( const Player & player )
     {
         serializer().serializeVisualPlayer( transport(),
                                             player,
-                                            calcName( player ),
+                                            calcPlayerName( player ),
                                             player.pos(),
                                             player.vel(),
                                             rad2Deg( player.angleBodyCommitted() ),
@@ -314,7 +332,7 @@ VisualSenderCoachV13::serializePlayer( const Player & player )
     {
         serializer().serializeVisualPlayer( transport(),
                                             player,
-                                            calcName( player ),
+                                            calcPlayerName( player ),
                                             player.pos(),
                                             player.vel(),
                                             rad2Deg( player.angleBodyCommitted() ),

--- a/src/visualsendercoach.h
+++ b/src/visualsendercoach.h
@@ -223,6 +223,8 @@ protected:
           return obj.name();
       }
 
+    virtual
+    const std::string & calcPlayerName( const Player & obj ) const;
 };
 
 /*!
@@ -258,6 +260,9 @@ protected:
       {
           return obj.shortName();
       }
+
+    virtual
+    const std::string & calcPlayerName( const Player & obj ) const;
 };
 
 /*!

--- a/src/visualsenderplayer.cpp
+++ b/src/visualsenderplayer.cpp
@@ -395,7 +395,7 @@ VisualSenderPlayerV1::sendLowPlayer( const Player & player )
             else
             {
                 serializer().serializeVisualObject( transport(),
-                                                    calcName( player ),
+                                                    calcPlayerName( player ),
                                                     calcDegDir( ang ) );
             }
         }
@@ -454,7 +454,7 @@ VisualSenderPlayerV1::sendHighPlayer( const Player & player )
                          un_quant_dist, quant_dist,
                          dist_chg, dir_chg );
                 serializePlayer( player,
-                                 calcName( player ),
+                                 calcPlayerName( player ),
                                  quant_dist,
                                  calcDegDir( ang ),
                                  dist_chg,

--- a/src/visualsenderplayer.cpp
+++ b/src/visualsenderplayer.cpp
@@ -1077,7 +1077,7 @@ RegHolder vp12 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPla
 RegHolder vp13 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPlayerV13 >, 13 );
 RegHolder vp14 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPlayerV13 >, 14 );
 RegHolder vp15 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPlayerV13 >, 15 );
-//RegHolder vp16 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPlayerV13 >, 16 );
+RegHolder vp16 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPlayerV13 >, 16 );
 }
 
 }

--- a/src/visualsenderplayer.h
+++ b/src/visualsenderplayer.h
@@ -355,6 +355,14 @@ protected:
       }
 
     virtual
+    const std::string & calcPlayerName( const Player & obj ) const
+      {
+          return self().side() == obj.side()
+              ? obj.name()
+              : obj.fixedName();
+      }
+
+    virtual
     const
     std::string & calcTFarName( const Player & obj ) const
       {
@@ -365,7 +373,9 @@ protected:
     const
     std::string & calcUFarName( const Player & obj ) const
       {
-          return obj.nameFar();
+          return self().side() == obj.side()
+              ? obj.nameFar()
+              : obj.fixedNameFar();
       }
 
 private:
@@ -491,10 +501,20 @@ public:
       }
 
     virtual
+    const std::string & calcPlayerName( const Player & obj ) const
+      {
+          return self().side() == obj.side()
+              ? obj.shortName()
+              : obj.fixedShortName();
+      }
+
+    virtual
     const
     std::string & calcUFarName( const Player & obj ) const
       {
-          return obj.shortNameFar();
+          return self().side() == obj.side()
+              ? obj.shortNameFar()
+              : obj.fixedShortNameFar();
       }
 
     virtual


### PR DESCRIPTION
implement a fixed_teamname feature for v16 simulator.

- add new parameters, server::fixed_teamname_[lr], as v16 server parameter.
- add v16 senders/serializers.
- replace the opponent team name in sensory messages if fixed_teamname values are given. 

