### PR TITLE
Replace boost with c++14

### DIFF
--- a/rcssbase/conf/paramgetter.hpp
+++ b/rcssbase/conf/paramgetter.hpp
@@ -22,7 +22,7 @@
 #ifndef PARAMGETTER_HPP
 #define PARAMGETTER_HPP
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace rcss {
 namespace conf {
@@ -121,7 +121,7 @@ public:
       }
 
 private:
-    boost::shared_ptr< rcss::conf::priv::GetterBase< RVal > > m_getter;
+    std::shared_ptr< rcss::conf::priv::GetterBase< RVal > > m_getter;
 };
 
 template< typename RVal >

--- a/rcssbase/conf/paramsetter.hpp
+++ b/rcssbase/conf/paramsetter.hpp
@@ -22,7 +22,7 @@
 #ifndef PARAMSETTER_HPP
 #define PARAMSETTER_HPP
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace rcss {
 namespace conf {
@@ -124,7 +124,7 @@ public:
       }
 
 private:
-    boost::shared_ptr< rcss::conf::priv::SetterBase< Arg > > m_setter;
+    std::shared_ptr< rcss::conf::priv::SetterBase< Arg > > m_setter;
 };
 
 template< typename Arg >

--- a/rcssbase/gzip/gzfstream.hpp
+++ b/rcssbase/gzip/gzfstream.hpp
@@ -25,8 +25,7 @@
 
 #include <iostream>
 #include <string>
-
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 
 namespace rcss {
@@ -83,7 +82,7 @@ public:
 private:
 
     //! Pimpl ideom. the instance of a file buffer.
-    boost::scoped_ptr< gzfilebuf_impl > M_impl;
+    std::unique_ptr< gzfilebuf_impl > M_impl;
 
     //! buffer size (default: 8192)
     std::size_t M_buf_size;
@@ -105,7 +104,7 @@ public:
     /*!
       \brief default constructor.
 
-      Default constructor creates an internal file buffer using boost::scoped_ptr.
+      Default constructor creates an internal file buffer using std::unique_ptr.
       This buffer is deleted automatically.
      */
     gzfilebuf();

--- a/rcssbase/gzip/gzstream.hpp
+++ b/rcssbase/gzip/gzstream.hpp
@@ -23,8 +23,7 @@
 #define GZSTREAM_H
 
 
-#include <boost/shared_ptr.hpp>
-
+#include <memory>
 #include <iostream>
 
 namespace rcss {
@@ -83,7 +82,7 @@ private:
     int M_remained;               // number of bytes remaining in M_output_buffer
     char_type M_remaining_char;
 
-    boost::shared_ptr< gzstreambuf_impl > m_streams;
+    std::shared_ptr< gzstreambuf_impl > m_streams;
     int M_level;                  // current level of compression/decompression
     // a level of -1 indicates that data is read
     // and written without modification.

--- a/rcssbase/net/addr.cpp
+++ b/rcssbase/net/addr.cpp
@@ -59,7 +59,7 @@ namespace net {
 const Addr::HostType Addr::BROADCAST = INADDR_BROADCAST;
 const Addr::HostType Addr::ANY = INADDR_ANY;
 
-class AddrImpl {
+class Addr::Impl {
 private:
     void setAddr( Addr::PortType port,
                   Addr::HostType host )
@@ -83,12 +83,12 @@ private:
           return true;
       }
 public:
-    AddrImpl( const Addr::AddrType & addr )
+    Impl( const Addr::AddrType & addr )
         : m_addr( addr )
       { }
 
-    AddrImpl( Addr::PortType port,
-              Addr::HostType host )
+    Impl( Addr::PortType port,
+          Addr::HostType host )
       {
           setAddr( htons( port ), htonl( host ) );
       }
@@ -207,15 +207,21 @@ private:
     int m_errno;
 };
 
+
 Addr::Addr( PortType port,
             HostType host )
-    : M_impl( new AddrImpl( port, host ) )
+    : M_impl( new Impl( port, host ) )
 {
 
 }
 
 Addr::Addr( const AddrType & addr )
-    : M_impl( new AddrImpl( addr ) )
+    : M_impl( new Impl( addr ) )
+{
+
+}
+
+Addr::~Addr()
 {
 
 }

--- a/rcssbase/net/addr.hpp
+++ b/rcssbase/net/addr.hpp
@@ -21,9 +21,8 @@
 #ifndef RCSS_NET_ADDR_HPP
 #define RCSS_NET_ADDR_HPP
 
-#include <boost/shared_ptr.hpp>
-#include <boost/cstdint.hpp>
-
+#include <memory>
+#include <cstdint>
 #include <string>
 
 struct sockaddr_in;
@@ -31,12 +30,14 @@ struct sockaddr_in;
 namespace rcss {
 namespace net {
 
-class AddrImpl;
-
 class Addr {
+private:
+    class Impl;
+
+    std::shared_ptr< Impl > M_impl;
 public:
-    typedef boost::uint16_t PortType;
-    typedef boost::uint32_t HostType;
+    typedef std::uint16_t PortType;
+    typedef std::uint32_t HostType;
     typedef struct sockaddr_in AddrType;
 
     enum Error { S_ADDR_OK, S_SERV_NOT_FOUND, S_HOST_NOT_FOUND };
@@ -49,6 +50,8 @@ public:
           HostType host = Addr::ANY );
 
     Addr( const AddrType & addr );
+
+    ~Addr();
 
     bool setPort( PortType port = 0 );
 
@@ -70,8 +73,6 @@ public:
 
     std::string getPortStr( const std::string & proto = "" ) const;
 
-private:
-    boost::shared_ptr< AddrImpl > M_impl;
 };
 
 

--- a/rcssbase/net/socket.cpp
+++ b/rcssbase/net/socket.cpp
@@ -85,8 +85,8 @@ Socket::Socket()
 
 Socket::Socket( SocketDesc s )
 {
-    M_handle = boost::shared_ptr< SocketDesc >( new SocketDesc( s ),
-                                                Socket::closeFD );
+    M_handle = std::shared_ptr< SocketDesc >( new SocketDesc( s ),
+                                              Socket::closeFD );
 }
 
 
@@ -104,8 +104,8 @@ Socket::open()
         return false;
     }
 
-    M_handle = boost::shared_ptr< SocketDesc >( new SocketDesc( s ),
-                                                Socket::closeFD );
+    M_handle = std::shared_ptr< SocketDesc >( new SocketDesc( s ),
+                                              Socket::closeFD );
 #ifndef RCSS_WIN
     int err = setCloseOnExec();
     if ( err < 0 )

--- a/rcssbase/net/socket.hpp
+++ b/rcssbase/net/socket.hpp
@@ -21,7 +21,7 @@
 #ifndef RCSS_NET_SOCKET_HPP
 #define RCSS_NET_SOCKET_HPP
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <rcssbase/net/addr.hpp>
 
@@ -124,7 +124,7 @@ protected:
     bool doOpen( SocketDesc& fd ) = 0;
 
 private:
-    boost::shared_ptr< SocketDesc > M_handle;
+    std::shared_ptr< SocketDesc > M_handle;
 };
 
 }

--- a/src/coach.cpp
+++ b/src/coach.cpp
@@ -39,8 +39,6 @@
 #include "initsenderonlinecoach.h"
 #include "visualsendercoach.h"
 
-#include <boost/lexical_cast.hpp>
-
 #include <iostream>
 #include <sstream>
 #include <cstdio>
@@ -410,7 +408,7 @@ Coach::sendExternalMsg()
     }
 
     std::string msg = "(include ";
-    msg += boost::lexical_cast< std::string >( buf.size() );
+    msg += std::to_string( buf.size() );
     msg += ' ';
     msg.append( buf.begin(), buf.end() );
     msg += ')';

--- a/src/heteroplayer.cpp
+++ b/src/heteroplayer.cpp
@@ -39,7 +39,7 @@
 #include "playerparam.h"
 #include "utility.h"
 
-#include <boost/random.hpp>
+#include <random>
 
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h> /* needed for htonl, htons, ... */
@@ -50,10 +50,6 @@
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
-#endif
-
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h> // gettimeofday
 #endif
 
 HeteroPlayer::HeteroPlayer()
@@ -168,7 +164,7 @@ HeteroPlayer::delta( const double & min,
                      const double & max )
 {
     static bool s_seeded = false;
-    static boost::mt19937 s_engine;
+    static std::mt19937 s_engine;
 
     if ( ! s_seeded )
     {
@@ -187,10 +183,9 @@ HeteroPlayer::delta( const double & min,
         }
         else
         {
-            timeval now;
-            gettimeofday ( &now, NULL );
+            std::random_device seed_gen;
+            const int seed = seed_gen();
 
-            int seed = static_cast< int >( now.tv_usec );
             PlayerParam::instance().setRandomSeed( seed );
             std::cout << "Hetero Player Seed: " << seed << std::endl;
             s_engine.seed( PlayerParam::instance().randomSeed() );
@@ -211,9 +206,8 @@ HeteroPlayer::delta( const double & min,
         std::swap( minv, maxv );
     }
 
-    boost::uniform_real< double > rng( minv, maxv );
-    boost::variate_generator< boost::mt19937&, boost::uniform_real<> > gen( s_engine, rng );
-    return gen();
+    std::uniform_real_distribution< double > rng( minv, maxv );
+    return rng( s_engine );
 }
 
 void

--- a/src/heteroplayer.cpp
+++ b/src/heteroplayer.cpp
@@ -41,15 +41,11 @@
 
 #include <random>
 
-#ifdef HAVE_SYS_PARAM_H
-#include <sys/param.h> /* needed for htonl, htons, ... */
+#ifdef HAVE_ARPA_INET_H
+#include <arpa/inet.h> /* needed for htonl, htons, ... */
 #endif
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h> /* needed for htonl, htons, ... */
-#endif
-
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
 #endif
 
 HeteroPlayer::HeteroPlayer()

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -44,7 +44,6 @@
 
 #include <rcssbase/gzip/gzfstream.hpp>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/convenience.hpp>
 
@@ -524,11 +523,11 @@ Logger::renameLogs()
             team_name_score += M_stadium.teamLeft().olcoach()->name();
             team_name_score += "_";
         }
-        team_name_score += boost::lexical_cast< std::string >( M_stadium.teamLeft().point() );
+        team_name_score += std::to_string( M_stadium.teamLeft().point() );
         if ( bAddPenaltyScore )
         {
             team_name_score += "_";
-            team_name_score += boost::lexical_cast< std::string >( M_stadium.teamLeft().penaltyPoint() );
+            team_name_score += std::to_string( M_stadium.teamLeft().penaltyPoint() );
             team_name_score += ( M_stadium.teamLeft().penaltyWon() ? "w" : "" );
         }
     }
@@ -547,11 +546,11 @@ Logger::renameLogs()
             team_name_score += M_stadium.teamRight().olcoach()->name();
             team_name_score += "_";
         }
-        team_name_score += boost::lexical_cast< std::string >( M_stadium.teamRight().point() );
+        team_name_score += std::to_string( M_stadium.teamRight().point() );
         if ( bAddPenaltyScore )
         {
             team_name_score += "_";
-            team_name_score += boost::lexical_cast< std::string >( M_stadium.teamRight().penaltyPoint() );
+            team_name_score += std::to_string( M_stadium.teamRight().penaltyPoint() );
             team_name_score += ( M_stadium.teamRight().penaltyWon() ? "w" : "" );
         }
     }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -42,15 +42,17 @@
 
 #include "serializercommonstdv8.h"
 
+#include <rcssbase/gzip/gzfstream.hpp>
+
 #include <boost/lexical_cast.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/convenience.hpp>
 
 #include <sstream>
 
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
+// #ifdef HAVE_SYS_TIME_H
+// #include <sys/time.h>
+// #endif
 // #ifdef HAVE_NETINET_IN_H
 // #include <netinet/in.h>
 // #endif
@@ -1436,14 +1438,14 @@ Logger::writeCoachStdAudio( const OnlineCoach & coach,
 
 
 void
-Logger::writeTimes( const timeval & old_time,
-                    const timeval & new_time )
+Logger::writeTimes( const std::chrono::system_clock::time_point & old_time,
+                    const std::chrono::system_clock::time_point & new_time )
 {
     if ( isTextLogOpen()
          && ServerParam::instance().logTimes() )
     {
-        double diff = (new_time.tv_sec - old_time.tv_sec) * 1000
-            + (double)(new_time.tv_usec - old_time.tv_usec) / 1000;
+        const std::chrono::nanoseconds nano_diff = std::chrono::duration_cast< std::chrono::nanoseconds >( new_time - old_time );
+        const double diff = nano_diff.count() * 0.001 * 0.001;
 
         *M_text_log << M_stadium.time()
                     << ',' << M_stadium.stoppageTime()
@@ -1452,15 +1454,15 @@ Logger::writeTimes( const timeval & old_time,
 }
 
 void
-Logger::writeProfile( const timeval & start_time,
-                      const timeval & end_time,
-                      const char * str )
+Logger::writeProfile( const std::chrono::system_clock::time_point & start_time,
+                      const std::chrono::system_clock::time_point & end_time,
+                      const std::string & str )
 {
     if ( isTextLogOpen()
          && ServerParam::instance().profile() )
     {
-        double diff = (end_time.tv_sec - start_time.tv_sec) * 1000
-            + (double)(end_time.tv_usec - start_time.tv_usec) / 1000;
+        const std::chrono::nanoseconds nano_diff = std::chrono::duration_cast< std::chrono::nanoseconds >( end_time - start_time );
+        const double diff = nano_diff.count() * 0.001 * 0.001;
 
         *M_text_log << M_stadium.time()
                     << ',' << M_stadium.stoppageTime()

--- a/src/logger.h
+++ b/src/logger.h
@@ -25,12 +25,10 @@
 
 #include "types.h"
 
-#include <rcssbase/gzip/gzfstream.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <string>
-
+#include <chrono>
 
 class Player;
 class Coach;
@@ -169,11 +167,11 @@ public:
     void writeCoachStdAudio( const OnlineCoach & coach,
                              const rcss::clang::Msg & msg );
 
-    void writeTimes( const timeval &,
-                     const timeval & );
-    void writeProfile( const timeval &,
-                       const timeval &,
-                       const char * );
+    void writeTimes( const std::chrono::system_clock::time_point & old_time,
+                     const std::chrono::system_clock::time_point & new_time );
+    void writeProfile( const std::chrono::system_clock::time_point & start_time,
+                       const std::chrono::system_clock::time_point & end_time,
+                       const std::string & str );
 };
 
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1447,11 +1447,8 @@ Player::goalieCatch( double dir )
     if ( min_catchable.inArea( rotated_pos ) )
     {
         //success = ( drand( 0, 1 ) <= SP.catchProb() );
-        boost::bernoulli_distribution<> rng( SP.catchProbability() );
-        boost::variate_generator< rcss::random::DefaultRNG &,
-            boost::bernoulli_distribution<> >
-            dst( rcss::random::DefaultRNG::instance(), rng );
-        success = dst();
+        std::bernoulli_distribution dst( SP.catchProbability() );
+        success = dst( DefaultRNG::instance().engine() );
         //std::cerr << M_stadium.time()
         //          << ": goalieCatch min_catchable ok" << std::endl;
     }
@@ -1464,11 +1461,8 @@ Player::goalieCatch( double dir )
         catch_prob = std::min( std::max( 0.0, catch_prob ), 1.0 );
 
         //success = ( drand( 0, 1 ) <= catch_prob );
-        boost::bernoulli_distribution<> rng( catch_prob );
-        boost::variate_generator< rcss::random::DefaultRNG &,
-            boost::bernoulli_distribution<> >
-            dst( rcss::random::DefaultRNG::instance(), rng );
-        success = dst();
+        std::bernoulli_distribution dst( catch_prob );
+        success = dst( DefaultRNG::instance().engine() );
         //std::cerr << M_stadium.time()
         //          << ": goalieCatch "
         //          << " dir=" << Rad2Deg( normalize_angle( angleBodyCommitted() + NormalizeMoment( dir ) ) )
@@ -1919,12 +1913,9 @@ Player::tackle( double power_or_angle,
 
     if ( prob < 1.0 )
     {
-        boost::bernoulli_distribution<> rng( 1 - prob );
-        boost::variate_generator< rcss::random::DefaultRNG &,
-            boost::bernoulli_distribution<> >
-            dst( rcss::random::DefaultRNG::instance(), rng );
+        std::bernoulli_distribution dst( 1 - prob );
 
-        if ( dst() )
+        if ( dst( DefaultRNG::instance().engine() ) )
         {
             M_state |= TACKLE;
 

--- a/src/random.h
+++ b/src/random.h
@@ -23,17 +23,18 @@
 #ifndef RCSSSERVER_RANDOM_H
 #define RCSSSERVER_RANDOM_H
 
-#include <boost/random.hpp>
-
+#include <random>
 #include <algorithm>
 #include <memory>
 #include <cstdlib>
 
-namespace rcss {
-namespace random {
+class DefaultRNG {
+private:
 
-class DefaultRNG
-    : public boost::mt19937 {
+    std::mt19937 M_engine;
+
+    DefaultRNG() = default;
+
 public:
     static
     DefaultRNG & instance()
@@ -43,52 +44,28 @@ public:
       }
 
     static
-    DefaultRNG &
-#if defined(__SUNPRO_CC) && (__SUNPRO_CC <= 0x520)
-    // Work around overload resolution problem (Gennadiy E. Rozental)
-    instance( const boost::mt19937::result_type & value )
-#else
-        instance( boost::mt19937::result_type value )
-#endif
+    DefaultRNG & instance( const std::mt19937::result_type & value )
       {
-          instance().seed( value );
+          instance().engine().seed( value );
           return instance();
       }
 
     // For GCC, moving this function out-of-line prevents inlining, which may
     // reduce overall object code size.  However, MSVC does not grok
     // out-of-line definitions of member function templates.
-    template< class Generator >
-    static
-    DefaultRNG & instance( Generator & gen )
-      {
-          instance().seed( gen );
-          return instance();
-      }
-private:
-    DefaultRNG()
-        : boost::mt19937()
-      { }
+    // template< class Generator >
+    // static
+    // DefaultRNG & instance( Generator & gen )
+    //   {
+    //       instance().engine().seed( gen() );
+    //       return instance();
+    //   }
+
+    std::mt19937 & engine()
+    {
+        return M_engine;
+    }
 };
-
-// class UniformRNG
-//     : public boost::random_number_generator< rcss::random::DefaultRNG >
-// {
-// public:
-//     static
-//     UniformRNG&
-//     instance ()
-//       { static UniformRNG the_instance; return the_instance; }
-//
-// private:
-//     UniformRNG()
-//         : boost::random_number_generator< rcss::random::DefaultRNG >( DefaultRNG::instance() )
-//       {}
-// };
-
-} // namespace random
-} // namespace rcss
-
 
 // old random code
 //#define RANDOMBASE		1000
@@ -102,9 +79,9 @@ int
 irand( int x )
 {
     if ( x <= 1 ) return 0;
-    //return boost::uniform_smallint<>( 0, x - 1 )( rcss::random::DefaultRNG::instance() );
-    //return (int)((double)x * std::rand() / (RAND_MAX + 1.0));
-    return rcss::random::DefaultRNG::instance()() % x;
+
+    std::uniform_int_distribution<> dst( 0, x - 1 );
+    return dst( DefaultRNG::instance().engine() );
 }
 
 inline
@@ -113,11 +90,9 @@ drand( double low, double high )
 {
     if ( low > high ) std::swap( low, high );
     if ( high - low < 1.0e-10 ) return (low + high) * 0.5;
-    //return boost::uniform_real<>( low, high )( rcss::random::DefaultRNG::instance() );
-    boost::uniform_real<> rng( low, high );
-    boost::variate_generator< rcss::random::DefaultRNG &, boost::uniform_real<> >
-      gen( rcss::random::DefaultRNG::instance(), rng );
-    return gen();
+
+    std::uniform_real_distribution<> rng( low, high );
+    return rng( DefaultRNG::instance().engine() );
 }
 
 #endif

--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -814,15 +814,11 @@ Referee::checkFoul( const Player & tackler,
     bool yellow_card = false;
     bool red_card = false;
 
-    boost::bernoulli_distribution<> rng( tackler.foulDetectProbability() );
-    boost::variate_generator< rcss::random::DefaultRNG &, boost::bernoulli_distribution<> >
-        dst( rcss::random::DefaultRNG::instance(), rng );
+    std::bernoulli_distribution dst( tackler.foulDetectProbability() );
 
     // 2011-05-14 akiyama
     // added red card probability
-    boost::bernoulli_distribution<> red_rng( ServerParam::instance().redCardProbability() );
-    boost::variate_generator< rcss::random::DefaultRNG &, boost::bernoulli_distribution<> >
-        red_dst( rcss::random::DefaultRNG::instance(), red_rng );
+    std::bernoulli_distribution red_dst( ServerParam::instance().redCardProbability() );
 
     const double ball_dist2 = tackler.pos().distance2( M_stadium.ball().pos() );
     const double ball_angle = ( M_stadium.ball().pos() - tackler.pos() ).th();
@@ -847,7 +843,7 @@ Referee::checkFoul( const Player & tackler,
             (*p)->setFoulCharged();
 
             //std::cerr << "---->" << (*p)->unum() << " intentional foul. prob=" << rng.p() << std::endl;
-            if ( dst() )
+            if ( dst( DefaultRNG::instance().engine() ) )
             {
                 //std::cerr << "----> " << (*p)->unum() << " detected intentional foul." << std::endl;
                 pre_check = true;
@@ -895,7 +891,7 @@ Referee::checkFoul( const Player & tackler,
             {
                 //std::cerr << "----> " << (*p)->unum() << " detected yellow_card." << std::endl;
                 yellow_card = true;
-                if ( red_dst() )
+                if ( red_dst( DefaultRNG::instance().engine() ) )
                 {
                     yellow_card = false;
                     red_card = true;
@@ -904,11 +900,11 @@ Referee::checkFoul( const Player & tackler,
         }
         else
         {
-            if ( dst() )
+            if ( dst( DefaultRNG::instance().engine() ) )
             {
                 //std::cerr << "----> " << (*p)->unum() << " detected foul. prob=" << rng.p() << std::endl;
                 foul_charge = true;
-                if ( red_dst() )
+                if ( red_dst( DefaultRNG::instance().engine() ) )
                 {
                     yellow_card = true;
                 }

--- a/src/stadium.cpp
+++ b/src/stadium.cpp
@@ -214,7 +214,7 @@ Stadium::init()
         std::cout << "Using given Simulator Random Seed: " << seed << std::endl;
         srand( seed );
         srandom( seed );
-        rcss::random::DefaultRNG::instance( static_cast< rcss::random::DefaultRNG::result_type >( seed ) );
+        DefaultRNG::instance( seed );
     }
     else
     {
@@ -223,7 +223,7 @@ Stadium::init()
         ServerParam::instance().setRandomSeed( seed );
         srand( seed );
         srandom( seed );
-        rcss::random::DefaultRNG::instance( static_cast< rcss::random::DefaultRNG::result_type >( seed ) );
+        DefaultRNG::instance( seed );
     }
 
     //std::cout << "Simulator Random Seed: " << ServerParam::instance().randomSeed() << std::endl;
@@ -935,9 +935,8 @@ Stadium::step()
 void
 Stadium::turnMovableObjects()
 {
-    std::random_shuffle( M_movable_objects.begin(),
-                         M_movable_objects.end(),
-                         irand );
+    std::shuffle( M_movable_objects.begin(), M_movable_objects.end(),
+                  DefaultRNG::instance().engine() );
     const MPObjectCont::iterator end = M_movable_objects.end();
     for ( MPObjectCont::iterator it = M_movable_objects.begin();
           it != end;
@@ -950,9 +949,8 @@ Stadium::turnMovableObjects()
 void
 Stadium::incMovableObjects()
 {
-    std::random_shuffle( M_movable_objects.begin(),
-                         M_movable_objects.end(),
-                         irand );
+    std::shuffle( M_movable_objects.begin(), M_movable_objects.end(),
+                  DefaultRNG::instance().engine() );
     const MPObjectCont::iterator end = M_movable_objects.end();
     for ( MPObjectCont::iterator it = M_movable_objects.begin();
           it != end;
@@ -2070,8 +2068,8 @@ Stadium::removeDisconnectedClients()
 void
 Stadium::sendRefereeAudio( const char * msg )
 {
-    std::random_shuffle( M_listeners.begin(), M_listeners.end(),
-                         irand ); //rcss::random::UniformRNG::instance() );
+    std::shuffle( M_listeners.begin(), M_listeners.end(),
+                  DefaultRNG::instance().engine() );
 
     // the following should work, but I haven't tested it yet
     //      std::for_each( M_listeners.begin(), M_listeners.end(),
@@ -2110,8 +2108,8 @@ void
 Stadium::sendPlayerAudio( const Player & player,
                           const char * msg )
 {
-    std::random_shuffle( M_listeners.begin(), M_listeners.end(),
-                         irand ); //rcss::random::UniformRNG::instance() );
+    std::shuffle( M_listeners.begin(), M_listeners.end(),
+                  DefaultRNG::instance().engine() );
 
     const ListenerCont::iterator end = M_listeners.end();
     for ( ListenerCont::iterator it = M_listeners.begin();
@@ -2146,8 +2144,8 @@ void
 Stadium::sendCoachAudio( const Coach & coach,
                          const char * msg )
 {
-    std::random_shuffle( M_listeners.begin(), M_listeners.end(),
-                         irand ); //rcss::random::UniformRNG::instance() );
+    std::shuffle( M_listeners.begin(), M_listeners.end(),
+                  DefaultRNG::instance().engine() );
 
     const ListenerCont::iterator end = M_listeners.end();
     for ( ListenerCont::iterator it = M_listeners.begin();
@@ -2187,8 +2185,8 @@ void
 Stadium::sendCoachStdAudio( const OnlineCoach & coach,
                             const rcss::clang::Msg & msg )
 {
-    std::random_shuffle( M_listeners.begin(), M_listeners.end(),
-                         irand ); //rcss::random::UniformRNG::instance() );
+    std::shuffle( M_listeners.begin(), M_listeners.end(),
+                  DefaultRNG::instance().engine() );
 
     const ListenerCont::iterator end = M_listeners.end();
     for ( ListenerCont::iterator it = M_listeners.begin();
@@ -2245,7 +2243,8 @@ Stadium::doRecvFromClients()
         s_time = M_time;
         s_stoppage_time = M_stoppage_time;
 
-        std::random_shuffle( M_shuffle_players.begin(), M_shuffle_players.end(), irand );
+        std::shuffle( M_shuffle_players.begin(), M_shuffle_players.end(),
+                      DefaultRNG::instance().engine() );
         for ( PlayerCont::iterator p = M_shuffle_players.begin(),
                   p_end = M_shuffle_players.end();
               p != p_end;
@@ -2297,8 +2296,8 @@ Stadium::doSendSenseBody()
 {
     const std::chrono::system_clock::time_point start_time = std::chrono::system_clock::now();
 
-    std::random_shuffle( M_remote_players.begin(), M_remote_players.end(),
-                         irand ); //rcss::random::UniformRNG::instance() );
+    std::shuffle( M_remote_players.begin(), M_remote_players.end(),
+                  DefaultRNG::instance().engine() );
 
     //
     // send sense_body & fullstate
@@ -2344,8 +2343,8 @@ Stadium::doSendVisuals()
 {
     const std::chrono::system_clock::time_point start_time = std::chrono::system_clock::now();
 
-    std::random_shuffle( M_remote_players.begin(), M_remote_players.end(),
-                         irand ); //rcss::random::UniformRNG::instance() );
+    std::shuffle( M_remote_players.begin(), M_remote_players.end(),
+                  DefaultRNG::instance().engine() );
 
     const PlayerCont::iterator end = M_remote_players.end();
     for ( PlayerCont::iterator it = M_remote_players.begin();
@@ -2368,8 +2367,8 @@ Stadium::doSendSynchVisuals()
 {
     const std::chrono::system_clock::time_point start_time = std::chrono::system_clock::now();
 
-    std::random_shuffle( M_remote_players.begin(), M_remote_players.end(),
-                         irand ); //rcss::random::UniformRNG::instance() );
+    std::shuffle( M_remote_players.begin(), M_remote_players.end(),
+                  DefaultRNG::instance().engine() );
 
     const PlayerCont::iterator end = M_remote_players.end();
     for ( PlayerCont::iterator it = M_remote_players.begin();
@@ -2609,8 +2608,8 @@ template < class T >
 void
 recv_from_clients( std::vector< T > & clients )
 {
-    std::random_shuffle( clients.begin(), clients.end(),
-                         irand ); //rcss::random::UniformRNG::instance() );
+    std::shuffle( clients.begin(), clients.end(),
+                  DefaultRNG::instance().engine() );
 
     for ( typename std::vector< T >::iterator i = clients.begin();
           i != clients.end(); )

--- a/src/types.h
+++ b/src/types.h
@@ -39,10 +39,10 @@
 
 #include "param.h"
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
-typedef boost::int16_t Int16;
-typedef boost::int32_t Int32;
+typedef std::int16_t Int16;
+typedef std::int32_t Int32;
 
 enum PlayerState {
     DISABLE =         0x00000000,

--- a/src/visualsenderplayer.cpp
+++ b/src/visualsenderplayer.cpp
@@ -894,12 +894,8 @@ VisualSenderPlayerV8::calcPointDir( const Player & player )
         //sigma is now in a range of 2.5 to 180 degrees, dependant on
         //the distance of the player.  95% of the returned random values
         //will be within +- 2*sigma of dir
-        boost::normal_distribution<> rng( dir, sigma );
-        boost::variate_generator< rcss::random::DefaultRNG &,
-            boost::normal_distribution<> >
-            gen( rcss::random::DefaultRNG::instance(), rng );
-
-        return rad2Deg( normalize_angle( gen() ) );
+        std::normal_distribution<> dst( dir, sigma );
+        return rad2Deg( normalize_angle( dst( DefaultRNG::instance().engine() ) ) );
     }
     else
     {

--- a/src/visualsenderplayer.h
+++ b/src/visualsenderplayer.h
@@ -316,7 +316,7 @@ private:
       {
           if ( prob >= 1.0 ) return true;
           if ( prob <= 0.0 ) return false;
-          return boost::bernoulli_distribution<>( prob )( random::DefaultRNG::instance() );
+          return std::bernoulli_distribution( prob )( DefaultRNG::instance().engine() );
       }
 
 protected:


### PR DESCRIPTION
Close #58
Some codes using boost are replaced using c++14 standard libraries.
We still need to use boost::filesystem and boost::any because they will be introduced c++17 or later.

Additionally, some time-related codes are replaced using std::chrono and std::this_thread.