### PR TITLE
Implement the rule of  the catch angle restriction

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -77,6 +77,15 @@ NormalizeKickPower( const double & p )
                         ServerParam::instance().maxPower() );
 }
 
+inline
+double
+NormalizeCatchAngle( const double d )
+{
+    return rcss::bound( ServerParam::instance().minCatchAngle(),
+                        d,
+                        ServerParam::instance().maxCatchAngle() );
+}
+
 // For v11 or older version
 inline
 double
@@ -1342,6 +1351,8 @@ Player::goalieCatch( double dir )
     {
         return;
     }
+
+    dir = NormalizeCatchAngle( dir );
 
     M_command_done = true;
     M_state |= CATCH;

--- a/src/serverparam.cpp
+++ b/src/serverparam.cpp
@@ -373,8 +373,8 @@ const double ServerParam::ILLEGAL_DEFENSE_WIDTH = 40.32;
 
 namespace {
 // 17.0.0
-constexpr double MAX_CATCH_ANGLE = +90.0;
-constexpr double MIN_CATCH_ANGLE = -90.0;
+constexpr double MAX_CATCH_ANGLE = +180.0;
+constexpr double MIN_CATCH_ANGLE = -180.0;
 }
 
 // XXX

--- a/src/serverparam.cpp
+++ b/src/serverparam.cpp
@@ -371,6 +371,12 @@ const int ServerParam::ILLEGAL_DEFENSE_NUMBER = 0;
 const double ServerParam::ILLEGAL_DEFENSE_DIST_X = 16.5;
 const double ServerParam::ILLEGAL_DEFENSE_WIDTH = 40.32;
 
+namespace {
+// 17.0.0
+constexpr double MAX_CATCH_ANGLE = +90.0;
+constexpr double MIN_CATCH_ANGLE = -90.0;
+}
+
 // XXX
 const double ServerParam::LONG_KICK_POWER_FACTOR = 2.0;
 const int ServerParam::LONG_KICK_DELAY = 2;
@@ -934,6 +940,10 @@ ServerParam::addParams()
               rcss::conf::makeGetter( M_fixed_teamname_r ),
               "", 16 );
 
+    // v17
+    addParam( "max_catch_angle", M_max_catch_angle, "", 17 );
+    addParam( "min_catch_angle", M_min_catch_angle, "", 17 );
+
     // XXX
     // addParam( "random_seed", M_random_seed, "", 999 );
     // addParam( "long_kick_power_factor", M_long_kick_power_factor, "", 999 );
@@ -1436,6 +1446,10 @@ ServerParam::setDefaults()
     M_illegal_defense_width = ILLEGAL_DEFENSE_WIDTH;
     M_fixed_teamname_l = "";
     M_fixed_teamname_r = "";
+
+    // 17.0.0
+    M_max_catch_angle = MAX_CATCH_ANGLE;
+    M_min_catch_angle = MIN_CATCH_ANGLE;
 
     // XXX
     M_long_kick_power_factor = LONG_KICK_POWER_FACTOR;

--- a/src/serverparam.h
+++ b/src/serverparam.h
@@ -336,14 +336,15 @@ private:
     static const bool GOLDEN_GOAL;
     // 15.0.0
     static const double RED_CARD_PROBABILITY;
-    // XXX
-    static const double LONG_KICK_POWER_FACTOR;
-    static const int LONG_KICK_DELAY;
     // 16.0.0
     static const int ILLEGAL_DEFENSE_DURATION;
     static const int ILLEGAL_DEFENSE_NUMBER;
     static const double ILLEGAL_DEFENSE_DIST_X;
     static const double ILLEGAL_DEFENSE_WIDTH;
+
+    // XXX
+    static const double LONG_KICK_POWER_FACTOR;
+    static const int LONG_KICK_DELAY;
 
     double M_goal_width; /* goal width */
     double M_inertia_moment; /* intertia moment for turn */
@@ -616,6 +617,10 @@ private:
     double M_illegal_defense_width;
     std::string M_fixed_teamname_l;
     std::string M_fixed_teamname_r;
+
+    // 17.0.0
+    double M_max_catch_angle;
+    double M_min_catch_angle;
 
     // XXX
     double M_long_kick_power_factor;
@@ -970,6 +975,10 @@ public:
     double illegalDefenseWidth() const { return M_illegal_defense_width; }
     const std::string & fixedTeamNameLeft() const { return M_fixed_teamname_l; }
     const std::string & fixedTeamNameRight() const { return M_fixed_teamname_r; }
+
+    // v17
+    double maxCatchAngle() const { return M_max_catch_angle; }
+    double minCatchAngle() const { return M_min_catch_angle; }
 
     // XXX
     double longKickPowerFactor() const { return M_long_kick_power_factor; }


### PR DESCRIPTION
- Add new parameters, server::max_catch_angle and server::min_catch_angle, as v17 parameter.
- Set their default value to +180.0 and -180.0
- Add the rule to restrict goalie's catch angle within [min_catch_angle, max_catch_angle]
- The new parameters are not sent to the player/coach because the v17 protocol has not been implemented.

This PR closes #62 