### PR TITLE
CMake: improve linking against Boost

### DIFF
--- a/rcss/CMakeLists.txt
+++ b/rcss/CMakeLists.txt
@@ -25,8 +25,6 @@ target_include_directories(RCSSBase
 
 target_link_libraries(RCSSBase
   INTERFACE
-    Boost::boost
-    Boost::system
     Boost::filesystem
 )
 

--- a/rcss/conf/CMakeLists.txt
+++ b/rcss/conf/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(RCSS::ConfParser ALIAS RCSSConfParser)
 
 target_link_libraries(RCSSConfParser
   PUBLIC
+    Boost::filesystem
+  PRIVATE
     Boost::boost
 )
 

--- a/rcss/gzip/CMakeLists.txt
+++ b/rcss/gzip/CMakeLists.txt
@@ -4,11 +4,6 @@ add_library(RCSSGZ SHARED
 )
 add_library(RCSS::GZ ALIAS RCSSGZ)
 
-target_link_libraries(RCSSGZ
-  PUBLIC
-    Boost::boost
-)
-
 target_compile_definitions(RCSSGZ
   PUBLIC
     HAVE_CONFIG_H

--- a/rcss/net/CMakeLists.txt
+++ b/rcss/net/CMakeLists.txt
@@ -10,11 +10,6 @@ add_library(RCSSNet SHARED
 )
 add_library(RCSS::Net ALIAS RCSSNet)
 
-target_link_libraries(RCSSNet
-  PUBLIC
-    Boost::boost
-)
-
 target_compile_definitions(RCSSNet
   PUBLIC
     HAVE_CONFIG_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,9 +92,7 @@ target_link_libraries(RCSSServer
     RCSS::ConfParser
     RCSS::Net
     RCSS::GZ
-    Boost::boost
     Boost::filesystem
-    Boost::system
     ZLIB::ZLIB
 	)
 
@@ -123,9 +121,6 @@ target_link_libraries(RCSSClient
   PRIVATE
     RCSS::Net
     RCSS::GZ
-    Boost::boost
-    Boost::filesystem
-    Boost::system
     ZLIB::ZLIB
 )
 


### PR DESCRIPTION
Often, linking against Boost is not required anymore because these components rely on the standard library instead.

Only the `RCSSConfParser` is required to additionally link against `Boost::filesystem`. Otherwise, compilation wouldn't work on macOS. `Boost::filesystem` isn't a header-only library and therefore not available through `Boost::boost`. Also `Boost::boost` doesn't need to be a public dependency there.