### PR TITLE
Keepaway: randomize initial position of the ball

### DIFF
--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3076,14 +3076,49 @@ KeepawayRef::resetField()
 
             p->place( PVector( x, y ) );
         }
-    }
+    }    
+    
+    // Randomize the position of the ball (at least 3 keepers are assumed, 
+    // consistent with the original keepaway implementation).
+    double ballX;
+    double ballY;
 
-    M_stadium.placeBall( NEUTRAL,
-                         PVector( -ServerParam::instance().keepAwayLength() * 0.5 + 4.0,
-                                  -ServerParam::instance().keepAwayWidth() * 0.5 + 4.0 ) );
+    KeepawayRef::ballInitialPosition(ballX, ballY);
+
+    M_stadium.placeBall( NEUTRAL, PVector(ballX, ballY) );
     M_stadium.recoveryPlayers();
 
     M_take_time = 0;
+}
+
+void
+KeepawayRef::ballInitialPosition( double & ballX, double & ballY )
+{
+    const double L = ServerParam::instance().keepAwayLength();
+    const double W = ServerParam::instance().keepAwayWidth();
+
+    const int quadrant = irand(3);
+    const int m = 4; // margin
+
+    // Randomly sample a position in the 1st, 2nd or 4th quadrant, leaving a safety margin of 4 units.
+    // This approach allows for uniform exploration of all quadrants.
+    switch(quadrant){
+    case 0: // quadrant 1
+        ballX = drand(m, L/2 - m);
+        ballY = drand(-W/2 + m, -m);
+        break;
+    case 1: // quadrant 2
+        ballX = drand(-L/2 + m, -m);
+        ballY = drand(-W/2 + m, -m);
+        break;
+    case 2: // quadrant 4
+        ballX = drand(m, L/2 - m);
+        ballY = drand(m, W/2 - m);
+        break;
+    default:
+        std::cout << "Error: unkown quadrant: " << quadrant << std::endl;
+        break;
+    }
 }
 
 

--- a/src/referee.h
+++ b/src/referee.h
@@ -848,6 +848,8 @@ private:
     void logEpisode( const char *endCond );
 
     void resetField();
+
+    void ballInitialPosition( double & ballX, double & ballY );
 };
 
 /*--------------------------------------------------------*/


### PR DESCRIPTION
I observed that, in Keepaway mode, the fact that the ball always gets initialized in the same position (top left corner) might introduce some bias in the policy learned by the players.
For example, I am training the _takers_ against a team of hand-coded _keepers_ (I'm actually using [this well-known library](https://www.cs.utexas.edu/~AustinVilla/sim/keepaway/)). The gif below shows two consecutive episodes, in which you can see that the takers intercept the ball even before the keepers get to pass the ball even once.

![kaway](https://user-images.githubusercontent.com/20436970/202510758-f0138bd9-e3c9-437a-8d7d-78051b0e1c03.gif)

To prevent this, the Keepaway mode could benefit from randomizing the ball's initial position when a new episode is restarted.
The way I overcame this problem was by initializing the ball in one of the quadrants occupied by the takers (if I'm not mistaken, Keepaway assumes a minimum of 3 keepers, and so do I).

Feel free to adopt this implementation or initialize the ball in any other way you may find more convenient.