### PR TITLE
Change the policy of update procedure of the focus point.

### DIFF
--- a/src/fullstatesender.cpp
+++ b/src/fullstatesender.cpp
@@ -480,8 +480,8 @@ FullStateSenderPlayerV18::sendPlayer( const Player & p )
                                          p.vel().y,
                                          Rad2Deg( p.angleBodyCommitted() ),
                                          Rad2Deg( p.angleNeckCommitted() ),
-                                         p.focusPointCommitted().getMag(),
-                                         Rad2Deg( p.focusPointCommitted().getHead() ) );
+                                         p.focusDist(),
+                                         Rad2Deg( p.focusDir() ) );
 
     if ( p.arm().isPointing() )
     {

--- a/src/object.h
+++ b/src/object.h
@@ -611,9 +611,6 @@ protected:
     void updateAngle() = 0;
 
     virtual
-    void updateFocusPoint() = 0;
-
-    virtual
     void collidedWithPost() = 0;
 
     virtual
@@ -650,10 +647,6 @@ public:
     virtual
     void updateAngle() override
       { }
-
-    virtual
-    void updateFocusPoint() override
-    { }
 
     virtual
     void collidedWithPost() override

--- a/src/player.h
+++ b/src/player.h
@@ -140,8 +140,10 @@ private:
     double M_angle_body_committed;
     double M_angle_neck; //!< temporary neck angle
     double M_angle_neck_committed;
-    rcss::geom::Vector2D M_focus_point; //!< temporary focus point
-    rcss::geom::Vector2D M_focus_point_committed;
+    double M_focus_dist; //!< distance to the focus point from the center of the player
+    double M_focus_dir; //!< direction to the focus point relative to the neck angle
+    PVector M_focus_point; //!< the global focus position on the pitch
+
     //
     // collision state
     //
@@ -154,7 +156,6 @@ private:
     //
     bool M_command_done;
     bool M_turn_neck_done;
-    bool M_change_focus_done;
     bool M_done_received; //pfr:SYNCH
 
     int M_goalie_catch_ban;
@@ -334,17 +335,18 @@ public:
     void decrementHearCapacity( const Player & sender );
     bool canHearFullFrom( const Player & sender ) const;
 
+    //
+    // body/sensor state
+    //
     const double & angleBodyCommitted() const { return M_angle_body_committed; }
     const double & angleNeckCommitted() const { return M_angle_neck_committed; }
-    const rcss::geom::Vector2D & focusPointCommitted() const { return M_focus_point_committed; }
-    rcss::geom::Vector2D focusPointCommittedGlobalPos() const {
-        rcss::geom::Vector2D focus_point_global_pos = focusPointCommitted();
-        focus_point_global_pos.setHead(normalize_angle(angleBodyCommitted() +
-                                                             angleNeckCommitted() +
-                                                             focus_point_global_pos.getHead()));
-        focus_point_global_pos += rcss::geom::Vector2D(pos().x, pos().y);
-        return focus_point_global_pos;
-    }
+    double focusDist() const { return M_focus_dist; }
+    double focusDir() const { return M_focus_dir; }
+    const PVector & focusPoint() const { return M_focus_point; }
+
+    //
+    // update stamina
+    //
 
     void recoverAll();
     void recoverStaminaCapacity();
@@ -352,7 +354,7 @@ public:
     void updateCapacity();
 
     //
-    // stamina
+    // stamina state
     //
     const double & stamina() const { return M_stamina; }
     const double & recovery() const { return M_recovery; }
@@ -447,8 +449,6 @@ protected:
     virtual
     void updateAngle() override;
     virtual
-    void updateFocusPoint() override;
-    virtual
     void collidedWithPost() override;
     virtual
     double maxAccel() const override;
@@ -456,6 +456,9 @@ protected:
     double maxSpeed() const override;
 
 private:
+
+    void updateFocusPoint();
+
     bool parseCommand( const char * command );
     int parseEar( const char * command );
 

--- a/src/serializermonitor.cpp
+++ b/src/serializermonitor.cpp
@@ -415,8 +415,8 @@ SerializerMonitorStdv5::serializePlayerPos( std::ostream & os,
        << ' ' << Quantize( player.vel().y, PREC )
        << ' ' << Quantize( Rad2Deg( player.angleBodyCommitted() ), DPREC )
        << ' ' << Quantize( Rad2Deg( player.angleNeckCommitted() ), DPREC )
-       << ' ' << Quantize( player.focusPointCommitted().getMag(), PREC )
-       << ' ' << Quantize( Rad2Deg( player.focusPointCommitted().getHead() ), PREC );
+       << ' ' << Quantize( player.focusDist(), PREC )
+       << ' ' << Quantize( Rad2Deg( player.focusDir() ), PREC );
 }
 /*
 //===================================================================
@@ -706,9 +706,9 @@ SerializerMonitorJSON::serializePlayerPos( std::ostream & os,
     os << ','
        << std::quoted( "neck" ) << ':' << Quantize( Rad2Deg( player.angleNeckCommitted() ), DIR_PREC );
     os << ','
-       << std::quoted( "focus_dist" ) << ':' << Quantize( player.focusPointCommitted().getMag(), POS_PREC )
+       << std::quoted( "focus_dist" ) << ':' << Quantize( player.focusDist(), POS_PREC )
        << ','
-       << std::quoted( "focus_dir" ) << ':' << Quantize( Rad2Deg( player.focusPointCommitted().getHead() ), POS_PREC );
+       << std::quoted( "focus_dir" ) << ':' << Quantize( Rad2Deg( player.focusDir() ), POS_PREC );
 }
 
 

--- a/src/visualsendercoach.cpp
+++ b/src/visualsendercoach.cpp
@@ -370,8 +370,8 @@ VisualSenderCoachV18::serializePlayer( const Player & player )
                                             player.vel(),
                                             rad2Deg( player.angleBodyCommitted() ),
                                             rad2Deg( player.angleNeckCommitted() ),
-                                            player.focusPointCommitted().getMag(),
-                                            rad2Deg( player.focusPointCommitted().getHead()),
+                                            player.focusDist(),
+                                            rad2Deg( player.focusDir() ),
                                             calcPointDir( player ) );
     }
     else
@@ -383,8 +383,8 @@ VisualSenderCoachV18::serializePlayer( const Player & player )
                                             player.vel(),
                                             rad2Deg( player.angleBodyCommitted() ),
                                             rad2Deg( player.angleNeckCommitted() ),
-                                            player.focusPointCommitted().getMag(),
-                                            rad2Deg( player.focusPointCommitted().getHead()) );
+                                            player.focusDist(),
+                                            rad2Deg( player.focusDir() ) );
     }
 }
 

--- a/src/visualsenderplayer.cpp
+++ b/src/visualsenderplayer.cpp
@@ -244,7 +244,7 @@ VisualSenderPlayerV1::sendHighFlag( const PObject & flag )
 //    const double quant_dist
 //            = calcQuantDist( un_quant_dist, self().landDistQStep() );
     const double quant_dist = calcQuantDistByFocusPoint( un_quant_dist,
-                                                         flag.pos().distance(self().focusPointCommittedGlobalPos()),
+                                                         flag.pos().distance( self().focusPoint() ),
                                                          self().landDistQStep() );
     if ( std::fabs( ang ) < self().visibleAngle() * 0.5
             && un_quant_dist < self().playerType()->flagMaxObservationLength() )
@@ -321,7 +321,7 @@ VisualSenderPlayerV1::sendHighBall( const MPObject & ball )
 //                                             self().distQStep() );
 
     const double quant_dist = calcQuantDistByFocusPoint( un_quant_dist,
-                                                         ball.pos().distance(self().focusPointCommittedGlobalPos()),
+                                                         ball.pos().distance( self().focusPoint() ),
                                                          self().distQStep() );
     if ( std::fabs( ang ) < self().visibleAngle() * 0.5
          && un_quant_dist < self().playerType()->ballMaxObservationLength())
@@ -433,7 +433,7 @@ VisualSenderPlayerV1::sendHighPlayer( const Player & player )
 //    const double quant_dist = calcQuantDist( un_quant_dist,
 //                                             self().distQStep() );
     const double quant_dist = calcQuantDistByFocusPoint( un_quant_dist,
-                                                         player.pos().distance(self().focusPointCommittedGlobalPos()),
+                                                         player.pos().distance( self().focusPoint() ),
                                                          self().distQStep() );
     if ( std::fabs( ang ) < self().visibleAngle() * 0.5
          && un_quant_dist < self().playerType()->playerMaxObservationLength())


### PR DESCRIPTION
- The distance and direction of the focus informaiton is now stored for each player object.
- The global position of the focus point is cached just after change_focus command and just before the cycle update in order to reduce the computational cost during the see message serialization.
- change_focus command can be performed several times in the same simulation cycle.