### PR TITLE
Force synch_see mode to v18+ player.

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -357,15 +357,23 @@ Player::init( const double ver,
         return false;
     }
 
+    return true;
+}
+
+
+void
+Player::initObservationMode()
+{
     if ( version() >= 18 )
     {
+        synch_see();
+
         M_wide_view_angle_noise_term = 1.0;
         M_normal_view_angle_noise_term = 0.75;
         M_narrow_view_angle_noise_term = 0.5;
     }
-
-    return true;
 }
+
 
 void
 Player::setPlayerType( const int id )

--- a/src/player.h
+++ b/src/player.h
@@ -202,6 +202,7 @@ public:
 
     bool init( const double ver,
                const bool goalie );
+    void initObservationMode();
     bool setSenders();
 
     void setEnable();

--- a/src/stadium.cpp
+++ b/src/stadium.cpp
@@ -628,6 +628,7 @@ Stadium::initPlayer( const char * teamname,
 
     player->setEnforceDedicatedPort( version >= 8.0 );
     player->sendInit();
+    player->initObservationMode();
 
     return player;
 }


### PR DESCRIPTION
We assume v18+ players always use synch_see mode for the new focus point feature. If players miss using syncn_see command, it causes a significant catastrophe for that player. The synch_see mode should be automatically turned on for v18+ player.