### PR TITLE
V18 develop observation (#95)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,7 @@ add_executable(RCSSServer
     serializercoachstdv8.cpp
     serializercoachstdv13.cpp
     serializercoachstdv14.cpp
-    serializercommonstdv1.cpp
+	serializercommonstdv1.cpp
     serializercommonstdv7.cpp
     serializercommonstdv8.cpp
     serializercommonjson.cpp
@@ -66,10 +66,12 @@ add_executable(RCSSServer
     serializeronlinecoachstdv13.cpp
     serializeronlinecoachstdv14.cpp
     serializerplayerstdv1.cpp
+    serializerplayerstdv5.cpp
     serializerplayerstdv7.cpp
     serializerplayerstdv8.cpp
     serializerplayerstdv13.cpp
     serializerplayerstdv14.cpp
+	serializerplayerstdv18.cpp
     serverparam.cpp
     stadium.cpp
     stdoutsaver.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,10 +49,12 @@ rcssserver_SOURCES = \
 	serializeronlinecoachstdv13.cpp \
 	serializeronlinecoachstdv14.cpp \
 	serializerplayerstdv1.cpp \
+	serializerplayerstdv5.cpp \
 	serializerplayerstdv7.cpp \
 	serializerplayerstdv8.cpp \
 	serializerplayerstdv13.cpp \
 	serializerplayerstdv14.cpp \
+	serializerplayerstdv18.cpp \
 	serverparam.cpp \
 	stadium.cpp \
 	stdoutsaver.cpp \
@@ -120,10 +122,12 @@ noinst_HEADERS = \
 	serializeronlinecoachstdv13.h \
 	serializeronlinecoachstdv14.h \
 	serializerplayerstdv1.h \
+	serializerplayerstdv5.h \
 	serializerplayerstdv7.h \
 	serializerplayerstdv8.h \
 	serializerplayerstdv13.h \
 	serializerplayerstdv14.h \
+	serializerplayerstdv18.h \
 	serializermonitor.h \
 	serverparam.h \
 	stadium.h \

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -984,6 +984,7 @@ RegHolder vp14 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlaye
 RegHolder vp15 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlayerv8 >, 15 );
 RegHolder vp16 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlayerv8 >, 16 );
 RegHolder vp17 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlayerv8 >, 17 );
+RegHolder vp18 = AudioSenderPlayer::factory().autoReg( &create< AudioSenderPlayerv8 >, 18 );
 
 template< typename Sender >
 AudioSender::Ptr
@@ -1009,6 +1010,7 @@ RegHolder vc14 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv
 RegHolder vc15 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv7 >, 15 );
 RegHolder vc16 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv7 >, 16 );
 RegHolder vc17 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv7 >, 17 );
+RegHolder vc18 = AudioSenderCoach::factory().autoReg( &create< AudioSenderCoachv7 >, 18 );
 
 template< typename Sender >
 AudioSender::Ptr
@@ -1034,5 +1036,6 @@ RegHolder voc14 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSende
 RegHolder voc15 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSenderOnlineCoachv7 >, 15 );
 RegHolder voc16 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSenderOnlineCoachv7 >, 16 );
 RegHolder voc17 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSenderOnlineCoachv7 >, 17 );
+RegHolder voc18 = AudioSenderOnlineCoach::factory().autoReg( &create< AudioSenderOnlineCoachv7 >, 18 );
 }
 }

--- a/src/bodysender.cpp
+++ b/src/bodysender.cpp
@@ -152,11 +152,12 @@ BodySenderPlayerV1::sendNeck()
 void
 BodySenderPlayerV1::sendCounts()
 {
-    serializer().serializeBodyCounts( transport(),
-                                      self().kickCount(),
-                                      self().dashCount(),
-                                      self().turnCount(),
-                                      self().sayCount() );
+    serializer().serializeBodyCounts( transport(), self() );
+    // serializer().serializeBodyCounts( transport(),
+    //                                   self().kickCount(),
+    //                                   self().dashCount(),
+    //                                   self().turnCount(),
+    //                                   self().sayCount() );
 }
 
 /*!
@@ -187,14 +188,6 @@ BodySenderPlayerV5::sendNeck()
     int ang = Rad2IDeg( self().angleNeckCommitted() );
     serializer().serializeNeckAngle( transport(),
                                      ang );
-}
-
-void
-BodySenderPlayerV5::sendCounts()
-{
-    BodySenderPlayerV1::sendCounts();
-    serializer().serializeNeckCount( transport(),
-                                     self().turnNeckCount() );
 }
 
 /*!
@@ -249,16 +242,6 @@ BodySenderPlayerV7::BodySenderPlayerV7( const Params & params )
 BodySenderPlayerV7::~BodySenderPlayerV7()
 {
 
-}
-
-void
-BodySenderPlayerV7::sendCounts()
-{
-    BodySenderPlayerV6::sendCounts();
-    serializer().serializeBodyCounts( transport(),
-                                      self().catchCount(),
-                                      self().moveCount(),
-                                      self().changeViewCount() );
 }
 
 /*!
@@ -400,7 +383,33 @@ BodySenderPlayerV14::sendBodyData()
     serializer().serializeFoul( transport(), self() );
 }
 
+/*!
+//===================================================================
+//
+//  CLASS: BodySenderPlayerV14
+//
+//  DESC: version 14 of the sense body protocol. Added foul charged & card info
+//
+//===================================================================
+*/
 
+BodySenderPlayerV18::BodySenderPlayerV18( const Params & params )
+    : BodySenderPlayerV14( params )
+{
+
+}
+
+BodySenderPlayerV18::~BodySenderPlayerV18()
+{
+
+}
+
+void
+BodySenderPlayerV18::sendBodyData()
+{
+    BodySenderPlayerV14::sendBodyData();
+    serializer().serializeFocusPoint( transport(), self() );
+}
 
 namespace bodysender {
 
@@ -428,6 +437,7 @@ RegHolder vp14 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV
 RegHolder vp15 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV14 >, 15 );
 RegHolder vp16 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV14 >, 16 );
 RegHolder vp17 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV14 >, 17 );
+RegHolder vp18 = BodySenderPlayer::factory().autoReg( &create< BodySenderPlayerV18 >, 18 );
 }
 
 }

--- a/src/bodysender.h
+++ b/src/bodysender.h
@@ -197,8 +197,6 @@ protected:
     virtual
     void sendCounts();
 
-public:
-
 };
 
 /*!
@@ -225,8 +223,6 @@ protected:
     virtual
     void sendNeck() override;
 
-    virtual
-    void sendCounts() override;
 };
 
 /*!
@@ -272,10 +268,6 @@ public:
 
     virtual
     ~BodySenderPlayerV7() override;
-
-protected:
-    virtual
-    void sendCounts() override;
 
 };
 
@@ -379,6 +371,30 @@ protected:
 
 };
 
+/*!
+//===================================================================
+//
+//  CLASS: BodySenderPlayerV18
+//
+//  DESC: version 18 of the sense body protocol. Added card info
+//
+//===================================================================
+*/
+
+class BodySenderPlayerV18
+    : public BodySenderPlayerV14
+{
+public:
+    BodySenderPlayerV18( const Params & params );
+
+    virtual
+    ~BodySenderPlayerV18() override;
+
+protected:
+    virtual
+    void sendBodyData() override;
+
+};
 }
 
 #endif

--- a/src/dispsender.cpp
+++ b/src/dispsender.cpp
@@ -486,6 +486,7 @@ DispSenderMonitorV3::sendShow()
         serializer().serializePlayerPos( ostr, *p );
         serializer().serializePlayerArm( ostr, *p );
         serializer().serializePlayerViewMode( ostr, *p );
+        serializer().serializePlayerFocusPoint( ostr, *p );
         serializer().serializePlayerStamina( ostr, *p );
         serializer().serializePlayerFocus( ostr, *p );
         serializer().serializePlayerCounts( ostr, *p );
@@ -512,15 +513,15 @@ DispSenderMonitorV3::sendMsg( const BoardType board,
 }
 
 
-// /*!
-// //===================================================================
-// //
-// //  CLASS: DispSenderMonitorJSON
-// //
-// //  DESC: version 5 of display protocol.
-// //
-// //===================================================================
-// */
+/*!
+//===================================================================
+//
+//  CLASS: DispSenderMonitorJSON
+//
+//  DESC: JSON protocol.
+//
+//===================================================================
+*/
 
 DispSenderMonitorJSON::DispSenderMonitorJSON( const Params & params )
     : DispSenderMonitor( params )
@@ -585,6 +586,7 @@ DispSenderMonitorJSON::sendShow()
         serializer().serializePlayerPos( ostr, *p );
         serializer().serializePlayerArm( ostr, *p );
         serializer().serializePlayerViewMode( ostr, *p );
+        serializer().serializePlayerFocusPoint( ostr, *p );
         serializer().serializePlayerStamina( ostr, *p );
         serializer().serializePlayerFocus( ostr, *p );
         //serializer().serializePlayerCounts( ostr, *p );
@@ -1011,6 +1013,7 @@ DispSenderLoggerV4::sendShow()
         serializer().serializePlayerPos( transport(), *p );
         serializer().serializePlayerArm( transport(), *p );
         serializer().serializePlayerViewMode( transport(), *p );
+        serializer().serializePlayerFocusPoint( transport(), *p );
         serializer().serializePlayerStamina( transport(), *p );
         serializer().serializePlayerFocus( transport(), *p );
         serializer().serializePlayerCounts( transport(), *p );
@@ -1039,7 +1042,7 @@ DispSenderLoggerV4::sendMsg( const BoardType board,
 //
 //  CLASS: DispSenderLoggerJSON
 //
-//  DESC: version 6 log format
+//  DESC: JSON log format
 //
 //===================================================================
 */
@@ -1135,7 +1138,8 @@ RegHolder vm1 = DispSenderMonitor::factory().autoReg( &create< DispSenderMonitor
 RegHolder vm2 = DispSenderMonitor::factory().autoReg( &create< DispSenderMonitorV2 >, 2 );
 RegHolder vm3 = DispSenderMonitor::factory().autoReg( &create< DispSenderMonitorV3 >, 3 );
 RegHolder vm4 = DispSenderMonitor::factory().autoReg( &create< DispSenderMonitorV3 >, 4 );
-RegHolder vm5 = DispSenderMonitor::factory().autoReg( &create< DispSenderMonitorJSON >, 5 );
+RegHolder vm5 = DispSenderMonitor::factory().autoReg( &create< DispSenderMonitorV3 >, 5 );
+RegHolder vmjson = DispSenderMonitor::factory().autoReg( &create< DispSenderMonitorJSON >, -1 );
 
 
 template< typename Sender >
@@ -1150,7 +1154,8 @@ RegHolder vl2 = DispSenderLogger::factory().autoReg( &create< DispSenderLoggerV2
 RegHolder vl3 = DispSenderLogger::factory().autoReg( &create< DispSenderLoggerV3 >, 3 );
 RegHolder vl4 = DispSenderLogger::factory().autoReg( &create< DispSenderLoggerV4 >, 4 );
 RegHolder vl5 = DispSenderLogger::factory().autoReg( &create< DispSenderLoggerV4 >, 5 );
-RegHolder vl6 = DispSenderLogger::factory().autoReg( &create< DispSenderLoggerJSON >, 6 );
+RegHolder vl6 = DispSenderLogger::factory().autoReg( &create< DispSenderLoggerV4 >, 6 );
+RegHolder vljson = DispSenderLogger::factory().autoReg( &create< DispSenderLoggerJSON >, -1 );
 
 }
 }

--- a/src/fullstatesender.cpp
+++ b/src/fullstatesender.cpp
@@ -293,15 +293,16 @@ FullStateSenderPlayerV8::sendSelf()
                              self().angleBodyCommitted()
                              + self().angleNeckCommitted(),
                              arm_vec );
-    serializer().serializeFSCounts( transport(),
-                                    self().kickCount(),
-                                    self().dashCount(),
-                                    self().turnCount(),
-                                    self().catchCount(),
-                                    self().moveCount(),
-                                    self().turnNeckCount(),
-                                    self().changeViewCount(),
-                                    self().sayCount() );
+    serializer().serializeFSCounts( transport(), self() );
+    // serializer().serializeFSCounts( transport(),
+    //                                 self().kickCount(),
+    //                                 self().dashCount(),
+    //                                 self().turnCount(),
+    //                                 self().catchCount(),
+    //                                 self().moveCount(),
+    //                                 self().turnNeckCount(),
+    //                                 self().changeViewCount(),
+    //                                 self().sayCount() );
     serializer().serializeArm( transport(),
                                self().arm().getCyclesTillMovable(),
                                self().arm().getCyclesTillExpiry(),
@@ -445,6 +446,69 @@ FullStateSenderPlayerV13::sendPlayer( const Player & p )
 /*!
 //===================================================================
 //
+//  CLASS: FullStateSenderPlayerV18
+//
+//  DESC: version 13 of the full state protocol. The focus point
+//   information are added.
+//
+//===================================================================
+*/
+
+FullStateSenderPlayerV18::FullStateSenderPlayerV18( const Params & params )
+    : FullStateSenderPlayerV13( params )
+{
+
+}
+
+    FullStateSenderPlayerV18::~FullStateSenderPlayerV18()
+{
+
+}
+
+
+void
+FullStateSenderPlayerV18::sendPlayer( const Player & p )
+{
+    char side = ( p.team()->side() == LEFT ? 'l' : 'r' );
+    serializer().serializeFSPlayerBegin( transport(),
+                                         side,
+                                         p.unum(),
+                                         p.isGoalie(),
+                                         p.playerTypeId(),
+                                         p.pos().x,
+                                         p.pos().y,
+                                         p.vel().x,
+                                         p.vel().y,
+                                         Rad2Deg( p.angleBodyCommitted() ),
+                                         Rad2Deg( p.angleNeckCommitted() ) );
+
+    if ( p.arm().isPointing() )
+    {
+        rcss::geom::Vector2D arm_vec;
+        p.arm().getRelDest( rcss::geom::Vector2D( p.pos().x, p.pos().y ),
+                            p.angleBodyCommitted() + p.angleNeckCommitted(),
+                            arm_vec );
+        serializer().serializeFSPlayerArm( transport(),
+                                           arm_vec.getMag(),
+                                           arm_vec.getHead() );
+    }
+
+    serializer().serializeFSPlayerFocus( transport(), p );
+
+    serializer().serializeFSPlayerStamina( transport(),
+                                           p.stamina(),
+                                           p.effort(),
+                                           p.recovery(),
+                                           p.staminaCapacity() );
+
+    serializer().serializeFSPlayerState( transport(), p );
+
+    serializer().serializeFSPlayerEnd( transport() );
+}
+
+/*!
+//===================================================================
+//
 //  Register senders for different versions
 //
 //===================================================================
@@ -476,6 +540,7 @@ RegHolder vp14 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSen
 RegHolder vp15 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSenderPlayerV13 >, 15 );
 RegHolder vp16 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSenderPlayerV13 >, 16 );
 RegHolder vp17 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSenderPlayerV13 >, 17 );
+RegHolder vp18 = FullStateSenderPlayer::factory().autoReg( &create< FullStateSenderPlayerV18 >, 18 );
 }
 
 }

--- a/src/fullstatesender.h
+++ b/src/fullstatesender.h
@@ -294,6 +294,32 @@ protected:
     void sendPlayer( const Player & p ) override;
 };
 
+/*!
+//===================================================================
+//
+//  CLASS: FullStateSenderPlayerV18
+//
+//  DESC: version 18 of the full state protocol. The focus point or
+//  information are added.
+//
+//===================================================================
+*/
+
+class FullStateSenderPlayerV18
+    : public FullStateSenderPlayerV13
+{
+public:
+    FullStateSenderPlayerV18( const Params & );
+
+    virtual
+    ~FullStateSenderPlayerV18() override;
+
+protected:
+
+    virtual
+    void sendPlayer( const Player & p ) override;
+};
+
 
 }
 

--- a/src/heteroplayer.cpp
+++ b/src/heteroplayer.cpp
@@ -122,6 +122,8 @@ HeteroPlayer::HeteroPlayer()
                                          PP.catchAreaLengthStretchMax() );
         M_catchable_area_l_stretch = tmp_delta;
 
+        setDefaultObservationParams();
+
         //
         double real_speed_max
             = ( SP.maxPower() * M_dash_power_rate * M_effort_max )
@@ -232,8 +234,28 @@ HeteroPlayer::setDefault()
     M_kick_power_rate = SP.kickPowerRate();
     M_foul_detect_probability = SP.foulDetectProbability();
     M_catchable_area_l_stretch = 1.0;
+
+    // v18
+    setDefaultObservationParams();
 }
 
+void
+HeteroPlayer::setDefaultObservationParams()
+{
+    double maximum_dist_in_pitch = std::sqrt( std::pow( ServerParam::PITCH_LENGTH, 2 )
+                                              + std::pow( ServerParam::PITCH_WIDTH, 2 ) );
+    M_unum_far_length = 20.0;
+    M_unum_too_far_length = 40.0;
+    M_team_far_length = maximum_dist_in_pitch;  // was 40.0 updated by Nader Zare in 2022-10-13
+    M_team_too_far_length = maximum_dist_in_pitch;  // was 60.0 updated by Nader Zare in 2022-10-13
+    M_player_max_observation_length = maximum_dist_in_pitch;
+    M_ball_vel_far_length = 20.0;
+    M_ball_vel_too_far_length = 40.0;
+    M_ball_max_observation_length = maximum_dist_in_pitch;
+    M_flag_chg_far_length = 20.0;
+    M_flag_chg_too_far_length = 40.0;
+    M_flag_max_observation_length = maximum_dist_in_pitch;
+}
 std::ostream &
 HeteroPlayer::print( std::ostream & o ) const
 {
@@ -255,7 +277,19 @@ HeteroPlayer::print( std::ostream & o ) const
         = ( ( playerSpeedMax() * ( 1 - playerDecay() ) )
             / dashPowerRate() )
         - staminaIncMax();
-    o << "\tPower Cons @ max vel = " << power_cons_at_max_vel << std::endl;
+    o << "\tPower Cons @ max vel = " << power_cons_at_max_vel << '\n';
+    o << "\tUnum Far Length = " << unumFarLength() << '\n';
+    o << "\tUnum Too Far Length = " << unumTooFarLength() << '\n';
+    o << "\tTeam Far Length = " << teamFarLength() << '\n';
+    o << "\tTeam Too Far Length = " << teamTooFarLength() << '\n';
+    o << "\tPlayer Max Observation Length = " << playerMaxObservationLength() << '\n';
+    o << "\tBall Vel Far Length = " << ballVelFarLength() << '\n';
+    o << "\tBall Vel Too Far Length = " << ballVelTooFarLength() << '\n';
+    o << "\tBall Max Observation Length = " << ballMaxObservationLength() << '\n';
+    o << "\tFlag Chg Far Length = " << flagChgFarLength() << '\n';
+    o << "\tFlag Chg Too Far Length = " << flagChgTooFarLength() << '\n';
+    o << "\tFlag Max Observation Length = " << flagMaxObservationLength() << std::endl;
+
     return o;
 }
 
@@ -331,6 +365,23 @@ HeteroPlayer::printParamsSExp( std::ostream & o,
     to_sexp( o, "kick_power_rate", kickPowerRate() );
     to_sexp( o, "foul_detect_probability", foulDetectProbability() );
     to_sexp( o, "catchable_area_l_stretch", catchAreaLengthStretch() );
+
+    if ( version < 18 )
+    {
+        return;
+    }
+
+    to_sexp( o, "unum_far_length", unumFarLength() );
+    to_sexp( o, "unum_too_far_length", unumTooFarLength() );
+    to_sexp( o, "team_far_length", teamFarLength() );
+    to_sexp( o, "team_too_far_length", teamTooFarLength() );
+    to_sexp( o, "player_max_observation_length", playerMaxObservationLength() );
+    to_sexp( o, "ball_vel_far_length", ballVelFarLength() );
+    to_sexp( o, "ball_vel_too_far_length", ballVelTooFarLength() );
+    to_sexp( o, "ball_max_observation_length", ballMaxObservationLength() );
+    to_sexp( o, "flag_chg_far_length", flagChgFarLength() );
+    to_sexp( o, "flag_chg_too_far_length", flagChgTooFarLength() );
+    to_sexp( o, "flag_max_observation_length", flagMaxObservationLength() );
 }
 
 
@@ -367,5 +418,30 @@ HeteroPlayer::printParamsJSON( std::ostream & o,
         to_json_member( o, "foul_detect_probability", foulDetectProbability() );
         o << ',';
         to_json_member( o, "catchable_area_l_stretch", catchAreaLengthStretch() );
+    }
+    if ( version >= 18 ) // 14 > ??
+    {
+        o << ",";
+        to_json_member( o, "unum_far_length", unumFarLength() );
+        o << ",";
+        to_json_member( o, "unum_too_far_length", unumTooFarLength() );
+        o << ",";
+        to_json_member( o, "team_far_length", teamFarLength() );
+        o << ",";
+        to_json_member( o, "team_too_far_length", teamTooFarLength() );
+        o << ",";
+        to_json_member( o, "player_max_observation_length", playerMaxObservationLength() );
+        o << ",";
+        to_json_member( o, "ball_vel_far_length", ballVelFarLength() );
+        o << ",";
+        to_json_member( o, "ball_vel_too_far_length", ballVelTooFarLength() );
+        o << ",";
+        to_json_member( o, "ball_max_observation_length", ballMaxObservationLength() );
+        o << ",";
+        to_json_member( o, "flag_chg_far_length", flagChgFarLength() );
+        o << ",";
+        to_json_member( o, "flag_chg_too_far_length", flagChgTooFarLength() );
+        o << ",";
+        to_json_member( o, "flag_max_observation_length", flagMaxObservationLength() );
     }
 }

--- a/src/heteroplayer.h
+++ b/src/heteroplayer.h
@@ -58,6 +58,18 @@ public:
     double foulDetectProbability() const { return M_foul_detect_probability; }
     double catchAreaLengthStretch() const { return M_catchable_area_l_stretch; }
 
+    double unumFarLength() const { return M_unum_far_length; }
+    double unumTooFarLength() const { return M_unum_too_far_length; }
+    double teamFarLength() const { return M_team_far_length; }
+    double teamTooFarLength() const { return M_team_too_far_length; }
+    double playerMaxObservationLength() const { return M_player_max_observation_length; }
+    double ballVelFarLength() const { return M_ball_vel_far_length; }
+    double ballVelTooFarLength() const { return M_ball_vel_too_far_length; }
+    double ballMaxObservationLength() const { return M_ball_max_observation_length; }
+    double flagChgFarLength() const { return M_flag_chg_far_length; }
+    double flagChgTooFarLength() const { return M_flag_chg_too_far_length; }
+    double flagMaxObservationLength() const { return M_flag_max_observation_length; }
+
     std::ostream & print( std::ostream & o ) const;
 
     player_type_t convertToStruct( int id ) const;
@@ -71,6 +83,8 @@ private:
     double delta( const double & min,
                   const double & max );
     void setDefault();
+
+    void setDefaultObservationParams();
 
     double M_player_speed_max;
     double M_stamina_inc_max;
@@ -89,6 +103,18 @@ private:
     double M_foul_detect_probability;
     double M_catchable_area_l_stretch;
 
+    // v18
+    double M_unum_far_length;
+    double M_unum_too_far_length;
+    double M_team_far_length;
+    double M_team_too_far_length;
+    double M_player_max_observation_length;
+    double M_ball_vel_far_length;
+    double M_ball_vel_too_far_length;
+    double M_ball_max_observation_length;
+    double M_flag_chg_far_length;
+    double M_flag_chg_too_far_length;
+    double M_flag_max_observation_length;
 };
 
 inline

--- a/src/initsendercoach.cpp
+++ b/src/initsendercoach.cpp
@@ -222,6 +222,7 @@ RegHolder vc14 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderO
 RegHolder vc15 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderOfflineCoachV8 >, 15 );
 RegHolder vc16 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderOfflineCoachV8 >, 16 );
 RegHolder vc17 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderOfflineCoachV8 >, 17 );
+RegHolder vc18 = InitSenderOfflineCoach::factory().autoReg( &create< InitSenderOfflineCoachV8 >, 18 );
 }
 
 }

--- a/src/initsenderlogger.cpp
+++ b/src/initsenderlogger.cpp
@@ -475,6 +475,45 @@ InitSenderLoggerV5::sendHeader()
 /*
 //===================================================================
 //
+//  InitSenderLoggerV6
+//
+//===================================================================
+*/
+
+InitSenderLoggerV6::InitSenderLoggerV6( const Params & params )
+    : InitSenderLoggerV5( params,
+                          std::shared_ptr< InitSenderCommon >
+                          ( new InitSenderCommonV8( params.M_transport,
+                                                    params.M_serializer,
+                                                    params.M_stadium,
+                                                    999,  // accept all parameters
+                                                    true ) ) ) // new line
+{
+    // The version of the common sender has to be "8".
+    // The client version is set to "999" in order to send all parameters.
+}
+
+InitSenderLoggerV6::InitSenderLoggerV6( const Params & params,
+                                        const std::shared_ptr< InitSenderCommon > common )
+    : InitSenderLoggerV5( params, common )
+{
+
+}
+
+InitSenderLoggerV6::~InitSenderLoggerV6()
+{
+
+}
+
+void
+InitSenderLoggerV6::sendHeader()
+{
+    transport() << "ULG6" << std::endl;
+}
+
+/*
+//===================================================================
+//
 //  InitSenderLoggerJSON
 //
 //===================================================================
@@ -506,7 +545,7 @@ InitSenderLoggerJSON::~InitSenderLoggerJSON()
 void
 InitSenderLoggerJSON::sendHeader()
 {
-    transport() << "ULG6\n";
+    transport() << "JSON\n";
     transport() << "[\n";
 
     transport() << '{'
@@ -571,7 +610,10 @@ RegHolder vl2 = InitSenderLogger::factory().autoReg( &create< InitSenderLoggerV2
 RegHolder vl3 = InitSenderLogger::factory().autoReg( &create< InitSenderLoggerV3 >, 3 );
 RegHolder vl4 = InitSenderLogger::factory().autoReg( &create< InitSenderLoggerV4 >, 4 );
 RegHolder vl5 = InitSenderLogger::factory().autoReg( &create< InitSenderLoggerV5 >, 5 );
-RegHolder vl6 = InitSenderLogger::factory().autoReg( &create< InitSenderLoggerJSON >, 6 );
+RegHolder vl7 = InitSenderLogger::factory().autoReg( &create< InitSenderLoggerV6 >, 6 );
+
+RegHolder vljson = InitSenderLogger::factory().autoReg( &create< InitSenderLoggerJSON >, -1 );
+
 }
 
 }

--- a/src/initsenderlogger.h
+++ b/src/initsenderlogger.h
@@ -342,6 +342,26 @@ public:
 
 };
 
+
+class InitSenderLoggerV6
+        : public InitSenderLoggerV5 {
+public:
+    InitSenderLoggerV6( const Params & params );
+
+protected:
+    InitSenderLoggerV6( const Params & params,
+                        const std::shared_ptr< InitSenderCommon > common );
+
+public:
+    virtual
+    ~InitSenderLoggerV6() override;
+
+    virtual
+    void sendHeader() override;
+
+};
+
+
 /*!
   \brief version 6 of the init sender for Logger (JSON format)
 */

--- a/src/initsendermonitor.cpp
+++ b/src/initsendermonitor.cpp
@@ -379,7 +379,9 @@ RegHolder v1 = InitSenderMonitor::factory().autoReg( &create< InitSenderMonitorV
 RegHolder v2 = InitSenderMonitor::factory().autoReg( &create< InitSenderMonitorV2 >, 2 );
 RegHolder v3 = InitSenderMonitor::factory().autoReg( &create< InitSenderMonitorV3 >, 3 );
 RegHolder v4 = InitSenderMonitor::factory().autoReg( &create< InitSenderMonitorV3 >, 4 );
-RegHolder v5 = InitSenderMonitor::factory().autoReg( &create< InitSenderMonitorJSON >, 5 );
+RegHolder v5 = InitSenderMonitor::factory().autoReg( &create< InitSenderMonitorV3 >, 5 );
+RegHolder vjson = InitSenderMonitor::factory().autoReg( &create< InitSenderMonitorJSON >, -1 );
+
 }
 
 }

--- a/src/initsenderonlinecoach.cpp
+++ b/src/initsenderonlinecoach.cpp
@@ -301,6 +301,7 @@ RegHolder voc14 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderO
 RegHolder voc15 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderOnlineCoachV8 >, 15 );
 RegHolder voc16 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderOnlineCoachV8 >, 16 );
 RegHolder voc17 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderOnlineCoachV8 >, 17 );
+RegHolder voc18 = InitSenderOnlineCoach::factory().autoReg( &create< InitSenderOnlineCoachV8 >, 18 );
 }
 
 }

--- a/src/initsenderplayer.cpp
+++ b/src/initsenderplayer.cpp
@@ -282,6 +282,7 @@ RegHolder vp14 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV
 RegHolder vp15 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV8 >, 15 );
 RegHolder vp16 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV8 >, 16 );
 RegHolder vp17 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV8 >, 17 );
+RegHolder vp18 = InitSenderPlayer::factory().autoReg( &create< InitSenderPlayerV8 >, 18 );
 }
 
 }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -164,11 +164,9 @@ Logger::setSenders( const Stadium & stadium )
     }
 
     int log_version = ServerParam::instance().gameLogVersion();
-    int monitor_version = log_version - 1;
-    if ( log_version == REC_OLD_VERSION )
-    {
-        monitor_version = 1;
-    }
+    int monitor_version = ( log_version == REC_OLD_VERSION ? 1
+                            : log_version == REC_VERSION_JSON ? REC_VERSION_JSON
+                            : log_version - 1 );
 
     rcss::SerializerMonitor::Creator ser_cre;
     if ( ! rcss::SerializerMonitor::factory().getCreator( ser_cre, monitor_version ) )

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -104,7 +104,8 @@ Monitor::parseMsg( char * msg,
     char * str = msg;
     if ( str[ len - 1 ] != 0 )
     {
-        if ( version() >= 2.0 )
+        if ( version() < 0
+             || version() >= 2.0 )
         {
             sendMsg( MSG_BOARD,
                      "(warning message_not_null_terminated)" );

--- a/src/object.h
+++ b/src/object.h
@@ -53,6 +53,7 @@
 #include <memory>
 #include <iostream>
 #include <cmath>
+#include <rcss/vector.h>
 
 /*
  *===================================================================
@@ -148,6 +149,16 @@ public:
     double distance( const PVector & orig ) const
       {
           return ( PVector( *this ) -= orig ).r();
+      }
+
+    double distance2 ( const rcss::geom::Vector2D & orig) const
+      {
+          return std::pow(this->x - orig.getX(), 2) + std::pow(this->y - orig.getY(), 2);
+      }
+
+    double distance ( const rcss::geom::Vector2D & orig) const
+      {
+          return std::sqrt(this->distance2(orig));
       }
 
     const PVector & rotate( const double ang )

--- a/src/pcombuilder.h
+++ b/src/pcombuilder.h
@@ -80,6 +80,7 @@ public:
     virtual void dash( double power, double dir ) = 0;
     virtual void turn( double moment ) = 0;
     virtual void turn_neck( double moment ) = 0;
+    virtual void change_focus( double moment_dist, double moment_dir ) = 0;
     virtual void kick( double power, double dir ) = 0;
     virtual void long_kick( double power, double dir ) = 0;
     virtual void goalieCatch( double dir ) = 0;

--- a/src/player_command_parser.ypp
+++ b/src/player_command_parser.ypp
@@ -72,6 +72,7 @@ namespace
 %token RCSS_PCOM_DASH "dash"
 %token RCSS_PCOM_TURN "turn"
 %token RCSS_PCOM_TURN_NECK "turn_neck"
+%token RCSS_PCOM_CHANGE_FOCUS "change_focus"
 %token RCSS_PCOM_KICK "kick"
 %token RCSS_PCOM_LONG_KICK "long_kick"
 %token RCSS_PCOM_CATCH "catch"
@@ -132,6 +133,7 @@ command_list : command
 command : dash_com
           | turn_com
           | turn_neck_com
+          | change_focus_com
           | kick_com
           | long_kick_com
           | catch_com
@@ -170,6 +172,12 @@ turn_com : RCSS_PCOM_LP RCSS_PCOM_TURN floating_point_number RCSS_PCOM_RP
 turn_neck_com : RCSS_PCOM_LP RCSS_PCOM_TURN_NECK floating_point_number RCSS_PCOM_RP
                 {
                   BUILDER.turn_neck( $< m_double >3 );
+                }
+;
+
+change_focus_com : RCSS_PCOM_LP RCSS_PCOM_CHANGE_FOCUS floating_point_number floating_point_number RCSS_PCOM_RP
+                {
+                  BUILDER.change_focus( $< m_double >3, $< m_double >4 );
                 }
 ;
 

--- a/src/player_command_tok.lpp
+++ b/src/player_command_tok.lpp
@@ -54,6 +54,7 @@ EXP  ({REAL}|{INT})[eE]{INT}
 dash { return RCSS_PCOM_DASH; }
 turn { return RCSS_PCOM_TURN; }
 turn_neck { return RCSS_PCOM_TURN_NECK; }
+change_focus { return RCSS_PCOM_CHANGE_FOCUS; }
 kick { return RCSS_PCOM_KICK; }
 long_kick { return RCSS_PCOM_LONG_KICK; }
 catch { return RCSS_PCOM_CATCH; }

--- a/src/serializer.h
+++ b/src/serializer.h
@@ -333,7 +333,7 @@ public:
 
     virtual
     void serializeVisualBegin( std::ostream &,
-                               const int ) const
+                               const int /*time*/ ) const
       { }
 
     virtual
@@ -396,71 +396,6 @@ public:
                << ')';
       }
 
-    void serializeVisualObject( std::ostream & strm,
-                                const std::string & name,
-                                const double & dist,
-                                const int dir,
-                                const bool tackling ) const
-      {
-          strm << " (" << name << ' ' << dist << ' ' << dir;
-          if ( tackling )
-              strm << " t";
-          strm << ')';
-      }
-
-    void serializeVisualObject( std::ostream & strm,
-                                const std::string & name,
-                                const double & dist,
-                                const int dir,
-                                const int point_dir,
-                                const bool tackling ) const
-      {
-          strm << " (" << name << ' ' << dist << ' ' << dir
-               << ' ' << point_dir;
-          if ( tackling )
-              strm << " t";
-          strm << ')';
-      }
-
-    void serializeVisualObject( std::ostream & strm,
-                                const std::string & name,
-                                const double & dist,
-                                const int dir,
-                                const double & dist_chg,
-                                const double & dir_chg,
-                                const int body_dir,
-                                const int head_dir,
-                                const bool tackling ) const
-      {
-          strm << " (" << name << ' ' << dist << ' ' << dir
-               << ' ' << dist_chg << ' ' << dir_chg
-               << ' ' << body_dir << ' ' << head_dir;
-          if ( tackling )
-              strm << " t";
-          strm << ')';
-      }
-
-    void serializeVisualObject( std::ostream & strm,
-                                const std::string & name,
-                                const double & dist,
-                                const int dir,
-                                const double & dist_chg,
-                                const double & dir_chg,
-                                const int body_dir,
-                                const int head_dir,
-                                const int point_dir,
-                                const bool tackling ) const
-      {
-          strm << " (" << name << ' ' << dist << ' ' << dir
-               << ' ' << dist_chg << ' ' << dir_chg
-               << ' ' << body_dir << ' ' << head_dir
-               << ' ' << point_dir;
-          if ( tackling )
-              strm << " t";
-          strm << ')';
-      }
-
-
     virtual
     void serializeVisualPlayer( std::ostream &, /* strm */
                                 const Player &, /* player */
@@ -503,7 +438,6 @@ public:
                                 const int /* point_dir */ ) const
       { }
 
-
     virtual
     void serializeBodyBegin( std::ostream &,
                              const int ) const
@@ -539,26 +473,11 @@ public:
 
     virtual
     void serializeBodyCounts( std::ostream &,
-                              const int,
-                              const int,
-                              const int,
-                              const int ) const
-      { }
-
-    virtual
-    void serializeBodyCounts( std::ostream &,
-                              const int,
-                              const int,
-                              const int ) const
+                              const Player & ) const
       { }
 
     virtual
     void serializeNeckAngle( std::ostream &,
-                             const int ) const
-      { }
-
-    virtual
-    void serializeNeckCount( std::ostream &,
                              const int ) const
       { }
 
@@ -605,6 +524,11 @@ public:
       { }
 
     virtual
+    void serializeFocusPoint( std::ostream &,
+                              const Player & ) const
+      { }
+
+    virtual
     void serializeFSBegin( std::ostream &,
                            const int ) const
       { }
@@ -626,15 +550,33 @@ public:
 
     virtual
     void serializeFSCounts( std::ostream &,
-                            const int,
-                            const int,
-                            const int,
-                            const int,
-                            const int,
-                            const int,
-                            const int,
-                            const int ) const
+                            const Player & ) const
       { }
+
+    // virtual
+    // void serializeFSCounts( std::ostream &,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int ) const
+    //   { }
+
+    // virtual
+    // void serializeFSCounts( std::ostream &,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int,
+    //                         const int ) const
+    // { }
 
     virtual
     void serializeFSScore( std::ostream &,
@@ -656,18 +598,23 @@ public:
                                  const int,
                                  const bool,
                                  const int,
-                                 const double &,
-                                 const double &,
-                                 const double &,
-                                 const double &,
-                                 const double &,
-                                 const double & ) const
+                                 const double & /* x */,
+                                 const double & /* y */,
+                                 const double & /* vx */,
+                                 const double & /* vy */ ,
+                                 const double & /* body */ ,
+                                 const double & /* neck */ ) const
+      { }
+
+    virtual
+    void serializeFSPlayerFocus( std::ostream &,
+                                 const Player & ) const
       { }
 
     virtual
     void serializeFSPlayerArm( std::ostream &,
-                               const double &,
-                               const double & ) const
+                               const double & /* point_dist */,
+                               const double & /* point_dir */ ) const
       { }
 
     virtual
@@ -780,7 +727,7 @@ public:
 
     virtual
     void serializeVisualBegin( std::ostream &,
-                               const int ) const
+                               const int /*time*/ ) const
       { }
 
     virtual
@@ -839,28 +786,26 @@ public:
                                 const bool ) const
       { }
 
-
     virtual
     void serializeVisualPlayer( std::ostream &,
                                 const Player &,
-                                const std::string &,
-                                const PVector &,
-                                const PVector &,
-                                const int,
-                                const int ) const
+                                const std::string & /*name*/,
+                                const PVector & /*pos*/,
+                                const PVector & /*vel*/,
+                                const int /*body*/,
+                                const int /*neck*/ ) const
       { }
 
     virtual
     void serializeVisualPlayer( std::ostream &,
                                 const Player &,
-                                const std::string &,
-                                const PVector &,
-                                const PVector &,
-                                const int,
-                                const int,
-                                const int ) const
+                                const std::string & /*name*/,
+                                const PVector & /*pos*/,
+                                const PVector & /*vel*/,
+                                const int /*body*/,
+                                const int /*neck*/,
+                                const int /*point_dir*/) const
       { }
-
 
     virtual
     void serializeOKEye( std::ostream &,
@@ -1053,7 +998,6 @@ public:
                                                    point_dir );
       }
 
-
 };
 
 
@@ -1144,6 +1088,10 @@ public:
     virtual
     void serializePlayerViewMode( std::ostream &,
                                   const Player & ) const
+      { }
+    virtual
+    void serializePlayerFocusPoint( std::ostream &,
+                                    const Player & ) const
       { }
     virtual
     void serializePlayerStamina( std::ostream &,

--- a/src/serializercoachstdv14.cpp
+++ b/src/serializercoachstdv14.cpp
@@ -138,6 +138,7 @@ RegHolder v14 = SerializerCoach::factory().autoReg( &SerializerCoachStdv14::crea
 RegHolder v15 = SerializerCoach::factory().autoReg( &SerializerCoachStdv14::create, 15 );
 RegHolder v16 = SerializerCoach::factory().autoReg( &SerializerCoachStdv14::create, 16 );
 RegHolder v17 = SerializerCoach::factory().autoReg( &SerializerCoachStdv14::create, 17 );
+RegHolder v18 = SerializerCoach::factory().autoReg( &SerializerCoachStdv14::create, 18 );
 }
 
 }

--- a/src/serializercommonstdv8.cpp
+++ b/src/serializercommonstdv8.cpp
@@ -110,6 +110,7 @@ RegHolder v14 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::cre
 RegHolder v15 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::create, 15 );
 RegHolder v16 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::create, 16 );
 RegHolder v17 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::create, 17 );
+RegHolder v18 = SerializerCommon::factory().autoReg( &SerializerCommonStdv8::create, 18 );
 }
 
 }

--- a/src/serializermonitor.cpp
+++ b/src/serializermonitor.cpp
@@ -356,6 +356,66 @@ SerializerMonitorStdv4::serializePlayerStamina( std::ostream & os,
 /*
 //===================================================================
 //
+//  SerializerMonitorStdv5
+//
+//===================================================================
+*/
+
+SerializerMonitorStdv5::SerializerMonitorStdv5( const SerializerCommon::Ptr common )
+        : SerializerMonitorStdv4( common )
+{
+
+}
+
+SerializerMonitorStdv5::~SerializerMonitorStdv5()
+{
+
+}
+
+const
+SerializerMonitor::Ptr
+SerializerMonitorStdv5::create()
+{
+    SerializerCommon::Creator cre_common;
+    if ( ! SerializerCommon::factory().getCreator( cre_common, 18 ) )
+    {
+        return SerializerMonitor::Ptr();
+    }
+
+    SerializerMonitor::Ptr ptr( new SerializerMonitorStdv5( cre_common() ) );
+    return ptr;
+}
+
+void
+SerializerMonitorStdv5::serializePlayerCounts( std::ostream & os,
+                                               const Player & player ) const
+{
+    os << " (c "
+       << player.kickCount() << ' '
+       << player.dashCount() << ' '
+       << player.turnCount() << ' '
+       << player.catchCount() << ' '
+       << player.moveCount() << ' '
+       << player.turnNeckCount() << ' '
+       << player.changeViewCount() << ' '
+       << player.sayCount() << ' '
+       << player.tackleCount() << ' '
+       << player.arm().getCounter() << ' '
+       << player.attentiontoCount() << ' '
+       << player.changeFocusCount() << ')';
+}
+
+void
+SerializerMonitorStdv5::serializePlayerFocusPoint( std::ostream & os,
+                                                   const Player & player ) const
+{
+    os << " (fp "
+       << Quantize( player.focusDist(), PREC ) << ' '
+       << Quantize( Rad2Deg( player.focusDir() ), PREC ) << ')';
+}
+/*
+//===================================================================
+//
 //  SerializerMonitorJSON (JSON)
 //
 //===================================================================
@@ -682,6 +742,26 @@ void SerializerMonitorJSON::serializePlayerViewMode( std::ostream & os,
 
 
 void
+SerializerMonitorJSON::serializePlayerFocusPoint( std::ostream & os,
+                                                  const Player & player ) const
+{
+    os << ',';
+#ifdef USE_FLAT_STYLE
+    os << std::quoted( "fdist" ) << ':' << Quantize( player.focusDist(), POS_PREC )
+       << ','
+       << std::quoted( "fdir" ) << ':' << Quantize( Rad2Deg( player.focusDir() ), DIR_PREC );
+#else
+    os << std::quoted( "focus_point" ) << ':'
+       << '{'
+       << std::quoted( "dist" ) << ':' << Quantize( player.focusDist(), POS_PREC )
+       << ','
+       << std::quoted( "dir" ) << ':' << Quantize( Rad2Deg( player.focusDir() ), DIR_PREC );
+       << '}';
+#endif
+}
+
+
+void
 SerializerMonitorJSON::serializePlayerStamina( std::ostream & os,
                                                const Player & player ) const
 {
@@ -716,7 +796,7 @@ void SerializerMonitorJSON::serializePlayerFocus( std::ostream & os,
          && player.getFocusTarget() )
     {
         os << ',';
-#if 1
+#ifdef USE_FLAT_STYLE
         os << std::quoted( "fside" ) << ':' << std::quoted( to_string( player.getFocusTarget()->side() ) )
            << ','
            << std::quoted( "fnum" ) << ':' << player.getFocusTarget()->unum();
@@ -775,6 +855,8 @@ SerializerMonitorJSON::serializePlayerCounts( std::ostream & os,
        << std::quoted( "pointto" ) << ':' << player.arm().getCounter()
        << ','
        << std::quoted( "attentionto" ) << ':' << player.attentiontoCount()
+       << ','
+       << std::quoted( "change_focus" ) << ':' << player.changeFocusCount()
        << '}';
 #endif
 }
@@ -864,7 +946,9 @@ RegHolder v1 = SerializerMonitor::factory().autoReg( &SerializerMonitorStdv1::cr
 RegHolder v2 = SerializerMonitor::factory().autoReg( &SerializerMonitorStdv1::create, 2 );
 RegHolder v3 = SerializerMonitor::factory().autoReg( &SerializerMonitorStdv3::create, 3 );
 RegHolder v4 = SerializerMonitor::factory().autoReg( &SerializerMonitorStdv4::create, 4 );
-RegHolder v5 = SerializerMonitor::factory().autoReg( &SerializerMonitorJSON::create, 5 );
+RegHolder v5 = SerializerMonitor::factory().autoReg( &SerializerMonitorStdv5::create, 5 );
+RegHolder vjson = SerializerMonitor::factory().autoReg( &SerializerMonitorJSON::create, -1 );
+
 }
 
 }

--- a/src/serializermonitor.h
+++ b/src/serializermonitor.h
@@ -164,6 +164,35 @@ public:
 
 
 /*!
+  \class SerializerMonitorStdv5
+  \brief class of the version 5 serialization for monitors. Add the focus point information.
+*/
+class SerializerMonitorStdv5
+        : public SerializerMonitorStdv4 {
+protected:
+
+    explicit
+    SerializerMonitorStdv5( const SerializerCommon::Ptr common );
+
+public:
+
+    virtual
+    ~SerializerMonitorStdv5() override;
+
+    static
+    const
+    Ptr create();
+
+    virtual
+    void serializePlayerCounts( std::ostream & os,
+                                const Player & player ) const override;
+    virtual
+    void serializePlayerFocusPoint( std::ostream & os,
+                                    const Player & player ) const override;
+};
+
+
+/*!
   \class SerializerMonitorJSON
   \brief class of the version 5 serialization for monitors. (JSON format)
 */
@@ -237,6 +266,10 @@ public:
     virtual
     void serializePlayerViewMode( std::ostream & os,
                                   const Player & player ) const override;
+
+    virtual
+    void serializePlayerFocusPoint( std::ostream & os,
+                                    const Player & player ) const override;
 
     virtual
     void serializePlayerStamina( std::ostream & os,

--- a/src/serializeronlinecoachstdv14.cpp
+++ b/src/serializeronlinecoachstdv14.cpp
@@ -64,6 +64,7 @@ RegHolder v14 = SerializerOnlineCoach::factory().autoReg( &SerializerOnlineCoach
 RegHolder v15 = SerializerOnlineCoach::factory().autoReg( &SerializerOnlineCoachStdv14::create, 15 );
 RegHolder v16 = SerializerOnlineCoach::factory().autoReg( &SerializerOnlineCoachStdv14::create, 16 );
 RegHolder v17 = SerializerOnlineCoach::factory().autoReg( &SerializerOnlineCoachStdv14::create, 17 );
+RegHolder v18 = SerializerOnlineCoach::factory().autoReg( &SerializerOnlineCoachStdv14::create, 18 );
 }
 
 }

--- a/src/serializerplayerstdv1.cpp
+++ b/src/serializerplayerstdv1.cpp
@@ -26,6 +26,7 @@
 #include "serializerplayerstdv1.h"
 
 #include "param.h"
+#include "player.h"
 
 #include <rcss/clang/clangmsg.h>
 
@@ -152,40 +153,50 @@ SerializerPlayerStdv1::serializeBodyVelocity( std::ostream & strm,
 
 void
 SerializerPlayerStdv1::serializeBodyCounts( std::ostream & strm,
-                                            const int count_kick,
-                                            const int count_dash,
-                                            const int count_turn,
-                                            const int count_say ) const
+                                            const Player & self ) const
 {
-    strm << " (kick " << count_kick << ')'
-         << " (dash " << count_dash << ')'
-         << " (turn " << count_turn << ')'
-         << " (say " << count_say << ')';
+    strm << " (kick " << self.kickCount() << ')'
+         << " (dash " << self.dashCount() << ')'
+         << " (turn " << self.turnCount() << ')'
+         << " (say " << self.sayCount() << ')';
 }
 
-void
-SerializerPlayerStdv1::serializeBodyCounts( std::ostream & strm,
-                                            const int count_catch,
-                                            const int count_move,
-                                            const int count_change_view ) const
-{
-    strm << " (catch " << count_catch << ')'
-         << " (move " << count_move << ')'
-         << " (change_view " << count_change_view << ')';
-}
+// void
+// SerializerPlayerStdv1::serializeBodyCounts( std::ostream & strm,
+//                                             const int count_kick,
+//                                             const int count_dash,
+//                                             const int count_turn,
+//                                             const int count_say ) const
+// {
+//     strm << " (kick " << count_kick << ')'
+//          << " (dash " << count_dash << ')'
+//          << " (turn " << count_turn << ')'
+//          << " (say " << count_say << ')';
+// }
+
+// void
+// SerializerPlayerStdv1::serializeBodyCounts( std::ostream & strm,
+//                                             const int count_catch,
+//                                             const int count_move,
+//                                             const int count_change_view ) const
+// {
+//     strm << " (catch " << count_catch << ')'
+//          << " (move " << count_move << ')'
+//          << " (change_view " << count_change_view << ')';
+// }
+
+// void
+// SerializerPlayerStdv1::serializeBodyCounts( std::ostream & strm,
+//                                             const int count_change_focus ) const
+// {
+//     strm << " (change_focus " << count_change_focus << ')';
+// }
 
 void
 SerializerPlayerStdv1::serializeNeckAngle( std::ostream & strm,
                                            const int ang ) const
 {
     strm << " (head_angle " << ang << ')';
-}
-
-void
-SerializerPlayerStdv1::serializeNeckCount( std::ostream & strm,
-                                           const int count_turn_neck ) const
-{
-    strm << " (turn_neck " << count_turn_neck << ')';
 }
 
 void
@@ -437,8 +448,6 @@ RegHolder v1 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv1::crea
 RegHolder v2 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv1::create, 2 );
 RegHolder v3 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv1::create, 3 );
 RegHolder v4 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv1::create, 4 );
-RegHolder v5 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv1::create, 5 );
-RegHolder v6 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv1::create, 6 );
 }
 
 }

--- a/src/serializerplayerstdv1.h
+++ b/src/serializerplayerstdv1.h
@@ -105,24 +105,11 @@ public:
 
     virtual
     void serializeBodyCounts( std::ostream & strm,
-                              const int count_kick,
-                              const int count_dash,
-                              const int count_turn,
-                              const int count_say ) const override;
-
-    virtual
-    void serializeBodyCounts( std::ostream & strm,
-                              const int count_catch,
-                              const int count_move,
-                              const int count_change_view ) const override;
+                              const Player & self ) const override;
 
     virtual
     void serializeNeckAngle( std::ostream & strm,
                              const int ang ) const override;
-
-    virtual
-    void serializeNeckCount( std::ostream & strm,
-                        const int count_turn_neck ) const override;
 
     virtual
     void serializeArm( std::ostream & strm,

--- a/src/serializerplayerstdv14.cpp
+++ b/src/serializerplayerstdv14.cpp
@@ -44,7 +44,7 @@ void
 SerializerPlayerStdv14::serializeFoul( std::ostream & strm,
                                        const Player & self ) const
 {
-    strm << " (foul "
+    strm << " (foul"
          << " (charged " << self.foulCycles() << ')';
 
     if ( self.hasRedCard() )

--- a/src/serializerplayerstdv18.cpp
+++ b/src/serializerplayerstdv18.cpp
@@ -1,0 +1,135 @@
+// -*-c++-*-
+
+/***************************************************************************
+                            serializerplayerstdv18.cpp
+                  Class for serializing data to std v14 players
+                             -------------------
+    begin                : 2022-10-08
+    copyright            : (C) 2023 by The RoboCup Soccer Server
+                           Maintenance Group.
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU LGPL as published by the Free Software  *
+ *   Foundation; either version 3 of the License, or (at your option) any  *
+ *   later version.                                                        *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "serializerplayerstdv18.h"
+
+#include "player.h"
+
+namespace rcss {
+
+SerializerPlayerStdv18::SerializerPlayerStdv18( const SerializerCommon::Ptr common )
+    : SerializerPlayerStdv14( common )
+{
+
+}
+
+SerializerPlayerStdv18::~SerializerPlayerStdv18()
+{
+
+}
+
+
+void
+SerializerPlayerStdv18::serializeBodyCounts( std::ostream & strm,
+                                             const Player & self ) const
+{
+    SerializerPlayerStdv14::serializeBodyCounts( strm, self );
+
+    strm << " (change_focus " << self.changeFocusCount() << ')';
+}
+
+
+void
+SerializerPlayerStdv18::serializeFSCounts( std::ostream & strm,
+                                           const Player & self ) const
+{
+    strm << " (count "
+         << self.kickCount() << ' '
+         << self.dashCount() << ' '
+         << self.turnCount() << ' '
+         << self.catchCount() << ' '
+         << self.moveCount() << ' '
+         << self.turnNeckCount() << ' '
+         << self.changeViewCount() << ' '
+         << self.sayCount() << ' '
+         << self.changeFocusCount() << ')';
+}
+
+
+// void
+// SerializerPlayerStdv18::serializeFSCounts( std::ostream & strm,
+//                                           const int count_kick,
+//                                           const int count_dash,
+//                                           const int count_turn,
+//                                           const int count_catch,
+//                                           const int count_move,
+//                                           const int count_turn_neck,
+//                                           const int count_change_view,
+//                                           const int count_say,
+//                                           const int count_change_focus) const
+// {
+//     strm << " (count "
+//          << count_kick << ' '
+//          << count_dash << ' '
+//          << count_turn << ' '
+//          << count_catch << ' '
+//          << count_move << ' '
+//          << count_turn_neck << ' '
+//          << count_change_view << ' '
+//          << count_say << ' '
+//          << count_change_focus
+//          << ')';
+// }
+
+void
+SerializerPlayerStdv18::serializeFocusPoint( std::ostream & strm,
+                                             const Player & self ) const
+{
+    strm << " (focus_point "
+         << self.focusDist()<< " "
+         << Rad2Deg( self.focusDir() );
+
+    strm << ')';
+}
+
+void
+SerializerPlayerStdv18::serializeFSPlayerFocus( std::ostream & strm,
+                                                const Player & p ) const
+
+{
+    strm << " (focus_point "
+         << p.focusDist() << ' '
+         << Rad2Deg( p.focusDir() )
+         << ')';
+}
+
+const
+SerializerPlayer::Ptr
+SerializerPlayerStdv18::create()
+{
+    SerializerCommon::Creator cre;
+    if ( ! SerializerCommon::factory().getCreator( cre, 18 ) )
+    {
+        return SerializerPlayer::Ptr();
+    }
+
+    SerializerPlayer::Ptr ptr( new SerializerPlayerStdv18( cre() ) );
+    return ptr;
+}
+
+namespace {
+RegHolder v18 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv18::create, 18 );
+}
+
+}

--- a/src/serializerplayerstdv18.h
+++ b/src/serializerplayerstdv18.h
@@ -1,0 +1,72 @@
+// -*-c++-*-
+
+/***************************************************************************
+                            serializerplayerstdv18.h
+                  Class for serializing data to std v18 players
+                             -------------------
+    begin                : 2022-10-08
+    copyright            : (C) 2022 by The RoboCup Soccer Server
+                           Maintenance Group.
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU LGPL as published by the Free Software  *
+ *   Foundation; either version 3 of the License, or (at your option) any  *
+ *   later version.                                                        *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef SERIALIZERPLAYERSTDV18_H
+#define SERIALIZERPLAYERSTDV18_H
+
+#include "serializerplayerstdv14.h"
+
+namespace rcss {
+
+class SerializerPlayerStdv18
+    : public SerializerPlayerStdv14 {
+protected:
+    SerializerPlayerStdv18( const SerializerCommon::Ptr common );
+
+public:
+    virtual
+    ~SerializerPlayerStdv18() override;
+
+    static
+    const
+    SerializerPlayer::Ptr create();
+
+    virtual
+    void serializeBodyCounts( std::ostream &,
+                              const Player & ) const override;
+
+    virtual
+    void serializeFSCounts( std::ostream & strm,
+                            const Player & self ) const override;
+    // virtual
+    // void serializeFSCounts( std::ostream & strm,
+    //                         const int count_kick,
+    //                         const int count_dash,
+    //                         const int count_turn,
+    //                         const int count_catch,
+    //                         const int count_move,
+    //                         const int count_turn_neck,
+    //                         const int count_change_view,
+    //                         const int count_say,
+    //                         const int count_change_focus) const override;
+
+    virtual
+    void serializeFocusPoint( std::ostream & strm,
+                              const Player & self ) const override;
+
+    virtual
+    void serializeFSPlayerFocus( std::ostream & strm,
+                                 const Player & p ) const override;
+
+};
+
+}
+
+#endif

--- a/src/serializerplayerstdv5.cpp
+++ b/src/serializerplayerstdv5.cpp
@@ -1,0 +1,72 @@
+// -*-c++-*-
+
+/***************************************************************************
+                            serializerplayerstdv5.cpp
+                  Class for serializing data to std v5 players
+                             -------------------
+    begin                : 2023-01-27
+    copyright            : (C) 2023 by The RoboCup Soccer Server
+                           Maintenance Group.
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU LGPL as published by the Free Software  *
+ *   Foundation; either version 3 of the License, or (at your option) any  *
+ *   later version.                                                        *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "serializerplayerstdv5.h"
+
+#include "player.h"
+
+namespace rcss {
+
+SerializerPlayerStdv5::SerializerPlayerStdv5( const SerializerCommon::Ptr common )
+    : SerializerPlayerStdv1( common )
+{
+
+}
+
+SerializerPlayerStdv5::~SerializerPlayerStdv5()
+{
+
+}
+
+
+void
+SerializerPlayerStdv5::serializeBodyCounts( std::ostream & strm,
+                                            const Player & self ) const
+{
+    SerializerPlayerStdv1::serializeBodyCounts( strm, self );
+
+    strm << " (turn_neck " << self.turnNeckCount() << ')';
+}
+
+const
+SerializerPlayer::Ptr
+SerializerPlayerStdv5::create()
+{
+    SerializerCommon::Creator cre;
+    if ( ! SerializerCommon::factory().getCreator( cre, 5 ) )
+    {
+        return SerializerPlayer::Ptr();
+    }
+
+    SerializerPlayer::Ptr ptr( new SerializerPlayerStdv5( cre() ) );
+    return ptr;
+}
+
+namespace {
+RegHolder v5 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv5::create, 5 );
+RegHolder v6 = SerializerPlayer::factory().autoReg( &SerializerPlayerStdv5::create, 6 );
+
+}
+
+}

--- a/src/serializerplayerstdv5.h
+++ b/src/serializerplayerstdv5.h
@@ -1,0 +1,51 @@
+// -*-c++-*-
+
+/***************************************************************************
+                            serializerplayerstdv5.h
+                  Class for serializing data to std v5 players
+                             -------------------
+    begin                : 2023-01-27
+    copyright            : (C) 2023 by The RoboCup Soccer Server
+                           Maintenance Group.
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU LGPL as published by the Free Software  *
+ *   Foundation; either version 3 of the License, or (at your option) any  *
+ *   later version.                                                        *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef SERIALIZERPLAYERSTDV5_H
+#define SERIALIZERPLAYERSTDV5_H
+
+#include "serializerplayerstdv1.h"
+
+namespace rcss {
+
+class SerializerPlayerStdv5
+    : public SerializerPlayerStdv1 {
+protected:
+    explicit
+    SerializerPlayerStdv5( const SerializerCommon::Ptr common );
+
+public:
+    virtual
+    ~SerializerPlayerStdv5() override;
+
+    static
+    const
+    Ptr create();
+
+    virtual
+    void serializeBodyCounts( std::ostream &,
+                              const Player & ) const override;
+
+};
+
+}
+
+#endif

--- a/src/serializerplayerstdv7.cpp
+++ b/src/serializerplayerstdv7.cpp
@@ -25,12 +25,14 @@
 
 #include "serializerplayerstdv7.h"
 
+#include "player.h"
+
 #include <rcss/clang/clangmsg.h>
 
 namespace rcss {
 
 SerializerPlayerStdv7::SerializerPlayerStdv7( const SerializerCommon::Ptr common )
-    : SerializerPlayerStdv1( common )
+    : SerializerPlayerStdv5( common )
 {
 
 }
@@ -167,6 +169,17 @@ SerializerPlayerStdv7::serializeChangePlayer( std::ostream & strm,
     strm << "(change_player_type "
          << unum << ' ' << type << ')';
 }
+
+void
+SerializerPlayerStdv7::serializeBodyCounts( std::ostream & strm,
+                                            const Player & self ) const
+{
+    SerializerPlayerStdv5::serializeBodyCounts( strm, self );
+    strm << " (catch " << self.catchCount() << ')'
+         << " (move " << self.moveCount() << ')'
+         << " (change_view " << self.changeViewCount() << ')';
+}
+
 
 const
 SerializerPlayer::Ptr

--- a/src/serializerplayerstdv7.h
+++ b/src/serializerplayerstdv7.h
@@ -22,12 +22,12 @@
 #ifndef SERIALIZERPLAYERSTDV7_H
 #define SERIALIZERPLAYERSTDV7_H
 
-#include "serializerplayerstdv1.h"
+#include "serializerplayerstdv5.h"
 
 namespace rcss {
 
 class SerializerPlayerStdv7
-    : public SerializerPlayerStdv1 {
+    : public SerializerPlayerStdv5 {
 protected:
     explicit
     SerializerPlayerStdv7( const SerializerCommon::Ptr common );
@@ -110,6 +110,10 @@ public:
     void serializeChangePlayer( std::ostream & strm,
                                 const int unum,
                                 const int type ) const;
+
+    virtual
+    void serializeBodyCounts( std::ostream &,
+                              const Player & ) const override;
 
 };
 

--- a/src/serializerplayerstdv8.cpp
+++ b/src/serializerplayerstdv8.cpp
@@ -219,25 +219,40 @@ SerializerPlayerStdv8::serializeFSPlayerStamina( std::ostream & strm,
 
 void
 SerializerPlayerStdv8::serializeFSCounts( std::ostream & strm,
-                                          const int count_kick,
-                                          const int count_dash,
-                                          const int count_turn,
-                                          const int count_catch,
-                                          const int count_move,
-                                          const int count_turn_neck,
-                                          const int count_change_view,
-                                          const int count_say ) const
+                                          const Player & self ) const
 {
     strm << " (count "
-         << count_kick << ' '
-         << count_dash << ' '
-         << count_turn << ' '
-         << count_catch << ' '
-         << count_move << ' '
-         << count_turn_neck << ' '
-         << count_change_view << ' '
-         << count_say << ')';
+         << self.kickCount() << ' '
+         << self.dashCount() << ' '
+         << self.turnCount() << ' '
+         << self.catchCount() << ' '
+         << self.moveCount() << ' '
+         << self.turnNeckCount() << ' '
+         << self.changeViewCount() << ' '
+         << self.sayCount() << ')';
 }
+
+// void
+// SerializerPlayerStdv8::serializeFSCounts( std::ostream & strm,
+//                                           const int count_kick,
+//                                           const int count_dash,
+//                                           const int count_turn,
+//                                           const int count_catch,
+//                                           const int count_move,
+//                                           const int count_turn_neck,
+//                                           const int count_change_view,
+//                                           const int count_say ) const
+// {
+//     strm << " (count "
+//          << count_kick << ' '
+//          << count_dash << ' '
+//          << count_turn << ' '
+//          << count_catch << ' '
+//          << count_move << ' '
+//          << count_turn_neck << ' '
+//          << count_change_view << ' '
+//          << count_say << ')';
+// }
 
 void
 SerializerPlayerStdv8::serializeServerParamBegin( std::ostream & strm ) const

--- a/src/serializerplayerstdv8.h
+++ b/src/serializerplayerstdv8.h
@@ -135,14 +135,18 @@ public:
 
     virtual
     void serializeFSCounts( std::ostream & strm,
-                            const int count_kick,
-                            const int count_dash,
-                            const int count_turn,
-                            const int count_catch,
-                            const int count_move,
-                            const int count_turn_neck,
-                            const int count_change_view,
-                            const int count_say ) const override;
+                            const Player & self ) const override;
+
+    // virtual
+    // void serializeFSCounts( std::ostream & strm,
+    //                         const int count_kick,
+    //                         const int count_dash,
+    //                         const int count_turn,
+    //                         const int count_catch,
+    //                         const int count_move,
+    //                         const int count_turn_neck,
+    //                         const int count_change_view,
+    //                         const int count_say ) const override;
 
     virtual
     void serializeServerParamBegin( std::ostream & strm ) const override;

--- a/src/stadium.cpp
+++ b/src/stadium.cpp
@@ -628,6 +628,7 @@ Stadium::initPlayer( const char * teamname,
 
     player->setEnforceDedicatedPort( version >= 8.0 );
     player->sendInit();
+    player->initObservationMode();
 
     return player;
 }
@@ -2799,9 +2800,17 @@ Stadium::parseMonitorInit( const char * message,
             delete mon;
             return true;
         }
-        std::cout << "A new (v" << ver << ") monitor connected." << std::endl;
 
-        mon->setEnforceDedicatedPort( ver >= 2.0 );
+        if ( ver < 0 )
+        {
+            std::cout << "A new (json) monitor connected." << std::endl;
+        }
+        else
+        {
+            std::cout << "A new (v" << ver << ") monitor connected." << std::endl;
+        }
+
+        mon->setEnforceDedicatedPort( ver < 0 || ver >= 2.0 );
         M_monitors.push_back( mon );
 
         // send server parameter information to monitor

--- a/src/types.h
+++ b/src/types.h
@@ -201,8 +201,8 @@ const int REC_VERSION_3 = 3;
 const int REC_VERSION_4 = 4;
 const int REC_VERSION_5 = 5;
 const int REC_VERSION_6 = 6;
-const int REC_VERSION_JSON = REC_VERSION_6;
-const int DEFAULT_REC_VERSION = REC_VERSION_5;
+const int REC_VERSION_JSON = -1;
+const int DEFAULT_REC_VERSION = REC_VERSION_6;
 
 enum DispInfoMode {
     NO_INFO = 0,

--- a/src/visualsendercoach.cpp
+++ b/src/visualsendercoach.cpp
@@ -370,6 +370,7 @@ RegHolder vc14 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoac
 RegHolder vc15 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoachV13 >, 15 );
 RegHolder vc16 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoachV13 >, 16 );
 RegHolder vc17 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoachV13 >, 17 );
+RegHolder vc18 = VisualSenderCoach::factory().autoReg( &create< VisualSenderCoachV13 >, 18 );
 }
 
 }

--- a/src/visualsenderplayer.cpp
+++ b/src/visualsenderplayer.cpp
@@ -107,20 +107,6 @@ VisualSenderPlayerV1::sendVisual()
     }
 
     serializer().serializeVisualBegin( transport(), stadium().time() );
-    if ( self().highQuality() )
-    {
-        M_send_flag = &VisualSenderPlayerV1::sendHighFlag;
-        M_send_ball = &VisualSenderPlayerV1::sendHighBall;
-        M_send_player = &VisualSenderPlayerV1::sendHighPlayer;
-        M_serialize_line = &VisualSenderPlayerV1::serializeHighLine;
-    }
-    else
-    {
-        M_send_flag = &VisualSenderPlayerV1::sendLowFlag;
-        M_send_ball = &VisualSenderPlayerV1::sendLowBall;
-        M_send_player = &VisualSenderPlayerV1::sendLowPlayer;
-        M_serialize_line = &VisualSenderPlayerV1::serializeLowLine;
-    }
     sendFlags();
     sendBalls();
     sendPlayers();
@@ -407,6 +393,7 @@ void
 VisualSenderPlayerV1::sendHighPlayer( const Player & player )
 {
     const double ang = calcRadDir( player );
+
     //const double un_quant_dist = calcUnQuantDist( player );
     double un_quant_dist = self().pos().distance2( player.pos() );
 
@@ -873,7 +860,7 @@ VisualSenderPlayerV8::calcPointDir( const Player & player )
         // NOTE: This means that 5% of the time it will be outside
         // of this range.
         double sigma = self().pos().distance( player.pos() )
-            / self().teamTooFarLength();
+            / self().playerType()->teamTooFarLength();
             //            / 60.0; // this should be replaced by the line below.
             //        //        / ServerParam::instance().getTeamTooFarLength ();
         sigma = std::pow( sigma, 4 ); // 4 should be parameterized
@@ -1039,6 +1026,304 @@ VisualSenderPlayerV13::~VisualSenderPlayerV13()
 /*!
 //===================================================================
 //
+//  CLASS: VisualSensorPlayerV18
+//
+//  DESC: Class for the version 13 visual protocol.  This version
+//        introduced the focus point.
+//
+//===================================================================
+*/
+
+VisualSenderPlayerV18::VisualSenderPlayerV18( const Params & params )
+    : VisualSenderPlayerV13( params )
+{
+
+}
+
+VisualSenderPlayerV18::~VisualSenderPlayerV18()
+{
+
+}
+
+void
+VisualSenderPlayerV18::sendLowFlag( const PObject & flag )
+{
+    const double ang = calcRadDir( flag );
+    const double un_quant_dist = calcUnQuantDist( flag );
+
+    if ( std::fabs( ang ) < self().visibleAngle() * 0.5
+         && un_quant_dist < self().playerType()->flagMaxObservationLength() )
+    {
+        serializer().serializeVisualObject( transport(),
+                                            calcName( flag ),
+                                            calcDegDir( ang ) );
+    }
+    else if ( un_quant_dist <= self().VISIBLE_DISTANCE )
+    {
+        serializer().serializeVisualObject( transport(),
+                                            calcCloseName( flag ),
+                                            calcDegDir( ang ) );
+    }
+}
+
+void
+VisualSenderPlayerV18::sendHighFlag( const PObject & flag )
+{
+    const double ang = calcRadDir( flag );
+    const double un_quant_dist = calcUnQuantDist( flag );
+    const double quant_dist = calcQuantDistFocusPoint( flag, un_quant_dist, self().landDistQStep() );
+
+    if ( std::fabs( ang ) < self().visibleAngle() * 0.5
+         && un_quant_dist < self().playerType()->flagMaxObservationLength() )
+    {
+        double prob = 0.0;
+        if ( self().playerType()->flagChgTooFarLength() > self().playerType()->flagChgFarLength() )
+        {
+            prob = ( ( quant_dist - self().playerType()->flagChgFarLength() )
+                    / ( self().playerType()->flagChgTooFarLength() - self().playerType()->flagChgFarLength() ) );
+        }
+
+        if ( decide( prob ) )
+        {
+            serializer().serializeVisualObject( transport(),
+                                                calcName( flag ),
+                                                quant_dist,
+                                                calcDegDir( ang ) );
+        }
+        else
+        {
+            double dist_chg, dir_chg;
+            calcVel( PVector(), flag.pos(),
+                     un_quant_dist, quant_dist,
+                     dist_chg, dir_chg );
+            serializer().serializeVisualObject( transport(),
+                                                calcName( flag ),
+                                                quant_dist,
+                                                calcDegDir( ang ),
+                                                dist_chg,
+                                                dir_chg );
+        }
+    }
+    else if ( un_quant_dist <= self().VISIBLE_DISTANCE )
+    {
+        serializer().serializeVisualObject( transport(),
+                                            calcCloseName( flag ),
+                                            quant_dist,
+                                            calcDegDir( ang ) );
+    }
+}
+
+
+void
+VisualSenderPlayerV18::sendLowBall( const MPObject & ball )
+{
+    const double ang = calcRadDir( ball );
+    const double un_quant_dist = calcUnQuantDist( ball );
+
+    if( std::fabs( ang ) < self().visibleAngle() * 0.5
+        && un_quant_dist < self().playerType()->ballMaxObservationLength())
+    {
+        serializer().serializeVisualObject( transport(),
+                                            calcName( ball ),
+                                            calcDegDir( ang ) );
+    }
+    else if( un_quant_dist <= self().VISIBLE_DISTANCE )
+    {
+        serializer().serializeVisualObject( transport(),
+                                            calcCloseName( ball ),
+                                            calcDegDir( ang ) );
+    }
+}
+
+
+void
+VisualSenderPlayerV18::sendHighBall( const MPObject & ball )
+{
+    const double ang = calcRadDir( ball );
+    const double un_quant_dist = calcUnQuantDist( ball );
+    const double quant_dist = calcQuantDistFocusPoint( ball,
+                                                       un_quant_dist,
+                                                       self().distQStep() );
+    if ( std::fabs( ang ) < self().visibleAngle() * 0.5
+         && un_quant_dist < self().playerType()->ballMaxObservationLength())
+    {
+        double prob = 0.0;
+        if ( self().playerType()->ballVelTooFarLength() > self().playerType()->ballVelFarLength() )
+        {
+            prob = ( ( quant_dist - self().playerType()->ballVelFarLength() )
+                    / ( self().playerType()->ballVelTooFarLength() - self().playerType()->ballVelFarLength() ) );
+        }
+
+        if ( decide( prob ) )
+        {
+            serializer().serializeVisualObject( transport(),
+                                                calcName( ball ),
+                                                quant_dist,
+                                                calcDegDir( ang ) );
+        }
+        else
+        {
+            double dist_chg, dir_chg;
+            calcVel( ball.vel(), ball.pos(),
+                     un_quant_dist, quant_dist,
+                     dist_chg, dir_chg );
+            serializer().serializeVisualObject( transport(),
+                                                calcName( ball ),
+                                                quant_dist,
+                                                calcDegDir( ang ),
+                                                dist_chg,
+                                                dir_chg );
+        }
+    }
+    else if ( un_quant_dist <= self().VISIBLE_DISTANCE )
+    {
+        serializer().serializeVisualObject( transport(),
+                                            calcCloseName( ball ),
+                                            quant_dist,
+                                            calcDegDir( ang ) );
+    }
+}
+
+
+void
+VisualSenderPlayerV18::sendLowPlayer( const Player & player )
+{
+    const double ang = calcRadDir( player );
+    const double un_quant_dist = calcUnQuantDist( player );
+
+    if ( std::fabs( ang ) < self().visibleAngle() * 0.5
+         && un_quant_dist < self().playerType()->playerMaxObservationLength() )
+    {
+        const double quant_dist = calcQuantDist( un_quant_dist,
+                                                 self().distQStep() );
+        double prob = 0.0;
+        if ( self().playerType()->teamTooFarLength() > self().playerType()->teamFarLength() )
+        {
+            prob = ( ( quant_dist - self().playerType()->teamFarLength() )
+                     / ( self().playerType()->teamTooFarLength() - self().playerType()->teamFarLength() ) );
+        }
+
+        if ( decide( prob ) )
+        {
+            serializer().serializeVisualObject( transport(),
+                                                calcTFarName( player ),
+                                                calcDegDir( ang ) );
+        }
+        else
+        {
+            prob = 0.0;
+            if ( self().playerType()->unumTooFarLength() > self().playerType()->unumFarLength() )
+            {
+                prob = ( ( quant_dist - self().playerType()->unumFarLength() )
+                         / ( self().playerType()->unumTooFarLength() - self().playerType()->unumFarLength() ) );
+            }
+
+            if ( decide( prob ) )
+            {
+                serializer().serializeVisualObject( transport(),
+                                                    calcUFarName( player ),
+                                                    calcDegDir( ang ) );
+            }
+            else
+            {
+                serializer().serializeVisualObject( transport(),
+                                                    calcPlayerName( player ),
+                                                    calcDegDir( ang ) );
+            }
+        }
+    }
+    else if ( un_quant_dist <= self().VISIBLE_DISTANCE )
+    {
+        serializer().serializeVisualObject( transport(),
+                                            calcCloseName( player ),
+                                            calcDegDir( ang ) );
+    }
+}
+
+
+void
+VisualSenderPlayerV18::sendHighPlayer( const Player & player )
+{
+    const double ang = calcRadDir( player );
+    const double un_quant_dist = self().pos().distance( player.pos() );
+    const double quant_dist = calcQuantDistFocusPoint( player,
+                                                       un_quant_dist,
+                                                       self().distQStep() );
+
+    if ( std::fabs( ang ) < self().visibleAngle() * 0.5
+         && un_quant_dist < self().playerType()->playerMaxObservationLength() )
+    {
+        double prob = 0.0;
+        if ( self().playerType()->teamTooFarLength() > self().playerType()->teamFarLength() )
+        {
+            prob = ( ( quant_dist - self().playerType()->teamFarLength() )
+                     / ( self().playerType()->teamTooFarLength() - self().playerType()->teamFarLength() ) );
+        }
+
+        if ( decide( prob ) )
+        {
+            // no team information
+            serializer().serializeVisualObject( transport(),
+                                                calcTFarName( player ),
+                                                quant_dist,
+                                                calcDegDir( ang ) );
+        }
+        else
+        {
+            prob = 0.0;
+            if ( self().playerType()->unumTooFarLength() > self().playerType()->unumFarLength() )
+            {
+                prob = ( ( quant_dist - self().playerType()->unumFarLength() )
+                         / ( self().playerType()->unumTooFarLength() - self().playerType()->unumFarLength() ) );
+            }
+
+            if ( decide( prob ) )
+            {
+                // no unum information
+                serializePlayer( player,
+                                 calcUFarName( player ),
+                                 quant_dist,
+                                 calcDegDir( ang ) );
+            }
+            else
+            {
+                double dist_chg, dir_chg;
+                calcVel( player.vel(), player.pos(),
+                         un_quant_dist, quant_dist,
+                         dist_chg, dir_chg );
+                serializePlayer( player,
+                                 calcPlayerName( player ),
+                                 quant_dist,
+                                 calcDegDir( ang ),
+                                 dist_chg,
+                                 dir_chg );
+            }
+        }
+    }
+    else if ( un_quant_dist <= player.VISIBLE_DISTANCE )
+    {
+        serializer().serializeVisualObject( transport(),
+                                            calcCloseName( player ),
+                                            quant_dist,
+                                            calcDegDir( ang ) );
+    }
+}
+
+double
+VisualSenderPlayerV18::calcQuantDistFocusPoint( const PObject & obj,
+                                                const double unquant_dist,
+                                                const double qstep )
+{
+    const double dist_focus_point = obj.pos().distance( self().focusPoint() );
+    const double quant_dist_focus_point = calcQuantDist( dist_focus_point, qstep );
+
+    return std::max( 0.0, unquant_dist - ( dist_focus_point - quant_dist_focus_point ) );
+}
+
+
+/*!
+//===================================================================
+//
 //  Register senders for different versions
 //
 //===================================================================
@@ -1069,6 +1354,7 @@ RegHolder vp14 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPla
 RegHolder vp15 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPlayerV13 >, 15 );
 RegHolder vp16 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPlayerV13 >, 16 );
 RegHolder vp17 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPlayerV13 >, 17 );
+RegHolder vp18 = VisualSenderPlayer::factory().autoReg( &create< VisualSenderPlayerV18 >, 18 );
 }
 
 }

--- a/src/visualsenderplayer.h
+++ b/src/visualsenderplayer.h
@@ -205,17 +205,23 @@ public:
 private:
     void sendFlag( const PObject & obj )
       {
-          (this->*M_send_flag)( obj );
+          self().highQuality()
+              ? sendHighFlag( obj )
+              : sendLowFlag( obj );
       }
 
     void sendBall( const MPObject & obj )
       {
-          (this->*M_send_ball)( obj );
+          self().highQuality()
+              ? sendHighBall( obj )
+              : sendLowBall( obj );
       }
 
     void sendPlayer( const Player & obj )
       {
-          (this->*M_send_player)( obj );
+          self().highQuality()
+              ? sendHighPlayer( obj )
+              : sendLowPlayer( obj );
       }
 
     void serializeLine( const std::string & name,
@@ -223,8 +229,9 @@ private:
                         const double & sight_2_line_ang,
                         const double & player_2_line )
       {
-          (this->*M_serialize_line)( name, dir,
-                                     sight_2_line_ang, player_2_line );
+          self().highQuality()
+              ? serializeHighLine( name, dir, sight_2_line_ang, player_2_line )
+              : serializeLowLine( name, dir, sight_2_line_ang, player_2_line );
       }
 
     void sendFlags();
@@ -235,16 +242,23 @@ private:
 
     void sendLines();
 
+protected:
+    virtual
     void sendLowFlag( const PObject & flag );
 
+    virtual
     void sendHighFlag( const PObject & flag );
 
+    virtual
     void sendLowBall( const MPObject & ball );
 
+    virtual
     void sendHighBall( const MPObject & ball );
 
+    virtual
     void sendLowPlayer( const Player & player );
 
+    virtual
     void sendHighPlayer( const Player & player );
 
     bool sendLine( const PObject & line );
@@ -270,6 +284,8 @@ private:
           return rad2Deg( rad_dir );
       }
 
+private:
+
     double calcLineRadDir( const double & line_normal ) const
       {
           return normalize_angle( line_normal
@@ -285,6 +301,7 @@ private:
               return calcDegDir( sight_2_line_ang + M_PI*0.5 );
       }
 
+protected:
     double calcUnQuantDist( const PObject & obj ) const
       {
           return self().pos().distance( obj.pos() );
@@ -380,14 +397,6 @@ protected:
               : obj.fixedNameFar();
       }
 
-private:
-    void (VisualSenderPlayerV1::*M_send_flag)( const PObject & );
-    void (VisualSenderPlayerV1::*M_send_ball)( const MPObject & );
-    void (VisualSenderPlayerV1::*M_send_player)( const Player & );
-    void (VisualSenderPlayerV1::*M_serialize_line)( const std::string &,
-                                                    const int,
-                                                    const double &,
-                                                    const double & );
 };
 
 /*!
@@ -618,6 +627,50 @@ public:
 
     virtual
     ~VisualSenderPlayerV13();
+
+};
+
+
+/*!
+//===================================================================
+//
+//  CLASS: VisualSensorPlayerV18
+//
+//  DESC: Class for the version 13 visual protocol.  This version
+//        introduced the focus point.
+//
+//===================================================================
+*/
+
+class VisualSenderPlayerV18
+    : public VisualSenderPlayerV13 {
+public:
+    VisualSenderPlayerV18( const Params & params );
+
+    virtual
+    ~VisualSenderPlayerV18();
+
+protected:
+
+    virtual
+    void sendLowFlag( const PObject & flag ) override;
+    virtual
+    void sendHighFlag( const PObject & flag ) override;
+
+    virtual
+    void sendLowBall( const MPObject & ball ) override;
+    virtual
+    void sendHighBall( const MPObject & ball ) override;
+
+    virtual
+    void sendLowPlayer( const Player & player ) override;
+    virtual
+    void sendHighPlayer( const Player & player ) override;
+
+    virtual
+    double calcQuantDistFocusPoint( const PObject & obj,
+                                    const double unquant_dist,
+                                    const double q_step );
 
 };
 


### PR DESCRIPTION
* Add observation variables into heteroplayer

* add distance and dictance2 functions in PVector to calculate its distance to Vector2D

* add observation variables into types.h

* add set_focus function into pcombuilder

* remove observation variables from player

* remove observation functions from player

* add focus variables and functions in player.h

* add view angles noise term into player.h and update QStep functions

* add focus variables and functions into player.cpp

* add NormalizeFocusAngle function into player.cpp

* change synch see M_visual_send_interval to 1 in player.cpp

* update visualsenderplayer to use focus point, hetero observation variables, and clean code

* fix bug in set focus, the committed focus point should be updated after updating pos.

* add focus count and focus pos into SerializerMonitorJSON

* add DispSenderLoggerV5, InitSenderLoggerV7, SerializerMonitorStdv5 to add focus pos and focus count into log

* fix a bug in updating focus point committed

* add vm6 into dispsender and v6 into initsendermonitor

* add visualsenderplayer vp18

* add serializeFocusPoint into serializerplayerstdv14

* add serializeBodyCounts into serializerplayerstdv1 to send set_focus count

* add serializeFocusPoint and serializeBodyCounts into serializer

* add InitSenderPlayer vp18 into initsenderplayer

* add BodySenderPlayerV18 into bodysender

* add AudioSenderPlayer into audio

* add FullStateSenderPlayer vp18 into fullstatesender

* implement serializerplayerstdv18 and add serializeFSPlayerBegin serializeFocusPoint

* add serializerplayerstdv18 into cmake

* implement FullStateSenderPlayerV18

* add serializeVisualPlayer and serializeFSPlayerBegin into serializer

* add serializeFSCounts into serializerplayerstdv18 to send set_focus count

* remove new hetero player observation params from types.h

* improve distance calculator functions of PVector

* change set_focus command parameters to dir_moment and dist_moment

* remove new hetero player from types

* add set_focus command parser in player_command_parser.ypp and player_command_tok.lpp

* update monitor serializer to send focus point information

* update player serializer to send focus point information

* remove serializeVisualPlayer from cmake file

* update coach serializers and visual sender to send focus point information

* update comments in serializer

* update view angles noise term to 1 for older player than 18 and 1,2,3 for player version 18

* update visual sender interval to 1 for player version >= 18 and 1,2,3 for older players

* update view angle noise terms to 1, 0.75, 0.5 to encourage teams to use the new model

* Fix the initialization procedure of observation noise terms

* Fix the order of arguments in Player::set_focus()

* change the order of set focus command and focus information to dist and then dir

* change set_focus to change_focus

* Change the policy of update procudure of the focus point.
- The distance and direction of the focus informaiton is now stored for each player object.
- The global position of the focus point is cached just after change_focus command and just before the cycle update in order to reduce the computational cost during the see message serialization.
- change_focus command can be performed several times in the same simulation cycle.

* Remove focus information from the online coaches' visual information

* Remove unused methods (serializeVisualPlayer) from Serializer class.

* Remove unused methods.

* Force synch_see mode to v18+ player.

* Add default observation distance parameters again.

* Add VisualSenderPlayerV18 for new observation model and revert older senders to keep the complete backward compatibility

* Fix coding conventions.

* Add serializerplayerstdv18.{h,cpp} to the build target. Separate focus info serialization to another method.

* Clean up the serialization of command count for the sense_body message.

* Clean up the serialization of command count for the fullstate message.

* Add SerializerPlayerStdv5 for the serialization of turn_neck count in sense_body messages

* Change the order of focus_point information in the fullstate message, and change the format to the s-exp element with 'focus_point' tag.

* Add v18 serializer of online coach as an alias of v14 serializer. Delete unused files.

* Fix problems of the serializer registration. Delete unnecessary class.

* Fix unintended value type of the moment_dir parameter in the change_focus command. Apply Deg2Rad function to convert from degree to radian.

* Fix the build problem caused by misconfiguration in CMakeLists.txt

* Apply the restriction of focus_dir when players perform change_view command.

* Change the format of the focus_point information in the monitor protocol.

* Fix the version number of monitor protocol and rcg format. Delete unused dispsender.

* Fix the version number of JSON monitor protocol.

* Fix the definition of log version.

* Fix the protocol version check for creating Logger instance.

* Rename InitSenderLoggerV7 to InitSenderLoggerV6 and fix key value for creator.

* Modify the console message when JSON protocol monitors connect.

* Set initial values to M_focus_dist and M_focus_dir in Player.

---------