### PR TITLE
Fix some parts related to the gausian_see flag.

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2274,10 +2274,8 @@ Player::synch_see()
 void
 Player::gaussian_see()
 {
-    if (version() >= 18.0){
-        M_gaussian_see = true;
-        send( "(ok gaussian_see)" );
-    }
+    M_gaussian_see = true;
+    send( "(ok gaussian_see)" );
 }
 
 void

--- a/src/player.h
+++ b/src/player.h
@@ -331,7 +331,7 @@ public:
 
     double changeDirFocusDistNoiseRate() const
       {
-        return 0.0125;  
+        return 0.0125;
       }
 
     double changeDistNoiseRate() const
@@ -379,8 +379,8 @@ public:
     double wideViewAngleNoiseTerm() const { return M_wide_view_angle_noise_term; }
     double normalViewAngleNoiseTerm() const { return M_normal_view_angle_noise_term; }
     double narrowViewAngleNoiseTerm() const { return M_narrow_view_angle_noise_term; }
-    bool gaussianSee() const { return M_gaussian_see; }
-    
+    bool isGaussianSee() const { return M_gaussian_see; }
+
     //
     // audio sensor
     //

--- a/src/visualsenderplayer.cpp
+++ b/src/visualsenderplayer.cpp
@@ -1130,9 +1130,9 @@ VisualSenderPlayerV18::sendGaussianFlag( const PObject & flag )
 {
     const double ang = calcRadDir( flag );
     const double actual_dist = calcUnQuantDist( flag );
-    const double focus_dist = flag.pos().distance( self().focusPoint() );
+    const double focus_dist = flag.pos().distance( M_focus_point );
     const double noisy_dist = calcGaussianDist( actual_dist, focus_dist,
-                                                self().landDistNoiseRate(), 
+                                                self().landDistNoiseRate(),
                                                 self().landFocusDistNoiseRate());
 
     if ( std::fabs( ang ) < self().visibleAngle() * 0.5
@@ -1250,9 +1250,9 @@ VisualSenderPlayerV18::sendGaussianBall( const MPObject & ball )
 {
     const double ang = calcRadDir( ball );
     const double actual_dist = calcUnQuantDist( ball );
-    const double focus_dist = ball.pos().distance( self().focusPoint() );
+    const double focus_dist = ball.pos().distance( M_focus_point );
     const double noisy_dist = calcGaussianDist( actual_dist, focus_dist,
-                                                self().distNoiseRate(), 
+                                                self().distNoiseRate(),
                                                 self().focusDistNoiseRate());
     if ( std::fabs( ang ) < self().visibleAngle() * 0.5
          && actual_dist < self().playerType()->ballMaxObservationLength() )
@@ -1427,7 +1427,7 @@ VisualSenderPlayerV18::calcQuantDistFocusPoint( const PObject & obj,
     const double quant_dist_focus_point = std::exp( Quantize( std::log( unquant_dist_focus_point + EPS ), qstep ) );
     const double quant_dist = std::exp( Quantize( std::log( qstep + EPS ), qstep ) );
 
-    const double observed_dist = std::max( 0.0, 
+    const double observed_dist = std::max( 0.0,
                                            unquant_dist - ( ( unquant_dist_focus_point - quant_dist_focus_point ) + ( unquant_dist - quant_dist ) ) / 2.0 );
 
     return Quantize( observed_dist, 0.1 );
@@ -1438,9 +1438,9 @@ VisualSenderPlayerV18::sendGaussianPlayer( const Player & player )
 {
     const double ang = calcRadDir( player );
     const double actual_dist = self().pos().distance( player.pos() );
-    const double focus_dist = player.pos().distance( self().focusPoint() );
+    const double focus_dist = player.pos().distance( M_focus_point );
     const double noisy_dist = calcGaussianDist( actual_dist, focus_dist,
-                                                self().distNoiseRate(), 
+                                                self().distNoiseRate(),
                                                 self().focusDistNoiseRate());
 
     if ( std::fabs( ang ) < self().visibleAngle() * 0.5
@@ -1513,7 +1513,7 @@ VisualSenderPlayerV18::calcGaussianDist( const double actual_dist,
     return std::max(0.0, ndrand(actual_dist, std_dev));
 }
 
-double 
+double
 VisualSenderPlayerV18::calcGaussianChangeDist( const double actual_dist_change,
                                                const double actual_dist,
                                                const double focus_dist,
@@ -1525,7 +1525,7 @@ VisualSenderPlayerV18::calcGaussianChangeDist( const double actual_dist_change,
     return ndrand(actual_dist_change, std_dev);
 }
 
-double 
+double
 VisualSenderPlayerV18::calcGaussianChangeDir( const double actual_dir_change,
                                               const double actual_dist,
                                               const double focus_dist,
@@ -1558,13 +1558,13 @@ VisualSenderPlayerV18::calcGaussianVel( const PVector & obj_vel,
 
         dir_chg = ( dir_chg == 0.0
                     ? 0.0
-                    : calcGaussianChangeDir( dir_chg, actual_dist, focus_dist, 
-                                             self().changeDirNoiseRate(), 
+                    : calcGaussianChangeDir( dir_chg, actual_dist, focus_dist,
+                                             self().changeDirNoiseRate(),
                                              self().changeDirFocusDistNoiseRate() ) );
         dist_chg = ( dist_chg == 0.0
                      ? 0.0
-                     : calcGaussianChangeDist( dist_chg, actual_dist, focus_dist, 
-                                               self().changeDistNoiseRate(), 
+                     : calcGaussianChangeDist( dist_chg, actual_dist, focus_dist,
+                                               self().changeDistNoiseRate(),
                                                self().changeDistFocusDistNoiseRate() ) );
     }
     else

--- a/src/visualsenderplayer.h
+++ b/src/visualsenderplayer.h
@@ -210,21 +210,21 @@ private:
     void sendFlag( const PObject & obj )
       {
           self().highQuality()
-              ? self().gaussianSee() ? sendGaussianFlag( obj ) : sendHighFlag( obj )
+              ? self().isGaussianSee() ? sendGaussianFlag( obj ) : sendHighFlag( obj )
               : sendLowFlag( obj );
       }
 
     void sendBall( const MPObject & obj )
       {
           self().highQuality()
-              ? self().gaussianSee() ? sendGaussianBall( obj ) : sendHighBall( obj )
+              ? self().isGaussianSee() ? sendGaussianBall( obj ) : sendHighBall( obj )
               : sendLowBall( obj );
       }
 
     void sendPlayer( const Player & obj )
       {
           self().highQuality()
-              ? self().gaussianSee() ? sendGaussianPlayer( obj ) : sendHighPlayer( obj )
+              ? self().isGaussianSee() ? sendGaussianPlayer( obj ) : sendHighPlayer( obj )
               : sendLowPlayer( obj );
       }
 
@@ -728,7 +728,7 @@ protected:
                           const double & actual_dist,
                           const double & focus_dist,
                           double & dist_chg,
-                          double & dir_chg ) const;                                    
+                          double & dir_chg ) const;
 };
 
 }


### PR DESCRIPTION
- Remove the the client version restriction when using the gaussian_see command.
- Rename Player::gaussianSee() with isGaussianSee() to avoid misuse of the function with a similar name.