### PR TITLE
New Synchronization Mode Parameters

### DIFF
--- a/src/serverparam.cpp
+++ b/src/serverparam.cpp
@@ -383,6 +383,11 @@ constexpr double DIST_NOISE_RATE = 0.0125;
 constexpr double FOCUS_DIST_NOISE_RATE = 0.0125;
 constexpr double LAND_DIST_NOISE_RATE = 0.00125;
 constexpr double LAND_FOCUS_DIST_NOISE_RATE = 0.00125;
+
+// 20.0.0
+constexpr int MAX_SYNCH_MODE_CYCLE_DURATION_MSEC = 1250;
+constexpr int MAX_ALLOWED_MISSED_SYNCH_MODE_CYCLES = 20;
+
 }
 
 // XXX
@@ -958,6 +963,12 @@ ServerParam::addParams()
     addParam( "land_dist_noise_rate", M_land_dist_noise_rate, "", 19 );
     addParam( "land_focus_dist_noise_rate", M_land_focus_dist_noise_rate, "", 19 );
 
+    // v20
+    addParam( "max_synch_mode_cycle_duration_msec", M_max_synch_mode_cycle_duration_msec, 
+              "The maximum cycle duration in milliseconds when synch mode is enabled. If the value is -1, the server will not check the missed cycles.", 20 ); 
+    addParam( "max_allowed_missed_synch_mode_cycles", M_max_allowed_missed_synch_mode_cycles, 
+              "The maximum allowed number of missed cycles when synch mode is enabled. If the value is -1, the server will not check the number of missed cycles.", 20 );
+
     // XXX
     // addParam( "random_seed", M_random_seed, "", 999 );
     // addParam( "long_kick_power_factor", M_long_kick_power_factor, "", 999 );
@@ -1479,6 +1490,11 @@ ServerParam::setDefaults()
     M_focus_dist_noise_rate = FOCUS_DIST_NOISE_RATE;
     M_land_dist_noise_rate = LAND_DIST_NOISE_RATE;
     M_land_focus_dist_noise_rate = LAND_FOCUS_DIST_NOISE_RATE;
+
+    // 20.0.0
+    M_max_synch_mode_cycle_duration_msec = MAX_SYNCH_MODE_CYCLE_DURATION_MSEC;
+    M_max_allowed_missed_synch_mode_cycles = MAX_ALLOWED_MISSED_SYNCH_MODE_CYCLES;
+
 //     std::string module_dir = S_MODULE_DIR;
 //     for ( std::string::size_type pos = module_dir.find( "//" );
 //           pos != std::string::npos;

--- a/src/serverparam.h
+++ b/src/serverparam.h
@@ -632,6 +632,10 @@ private:
     double M_land_dist_noise_rate;
     double M_land_focus_dist_noise_rate;
 
+    // 20.0.0
+    int M_max_synch_mode_cycle_duration_msec;
+    int M_max_allowed_missed_synch_mode_cycles;
+
 private:
 
     // setters & getters
@@ -995,6 +999,10 @@ public:
     double focusDistNoiseRate() const { return M_focus_dist_noise_rate; }
     double landDistNoiseRate() const { return M_land_dist_noise_rate; }
     double landFocusDistNoiseRate() const { return M_land_focus_dist_noise_rate; }
+
+    // v20
+    int maxSynchModeCycleDurationMsec() const { return M_max_synch_mode_cycle_duration_msec; }
+    int maxAllowedMissedSynchModeCycles() const { return M_max_allowed_missed_synch_mode_cycles; }
 };
 
 #endif


### PR DESCRIPTION
This pull request introduces new parameters to control synchronization mode cycle duration and the number of allowed missed cycles in the server configuration. The changes primarily involve adding these parameters to the `ServerParam` class and updating relevant methods to use these new parameters.

### New Synchronization Mode Parameters:

* [`src/serverparam.cpp`](diffhunk://#diff-a97677ec20fc7af6c5600418cccf6a9c9e19313d63ad9da762db47989c1cdbbcR386-R390): Added `MAX_SYNCH_MODE_CYCLE_DURATION_MSEC` and `MAX_ALLOWED_MISSED_SYNCH_MODE_CYCLES` constants to control the maximum cycle duration and the allowed number of missed cycles in synchronization mode.
* [`src/serverparam.cpp`](diffhunk://#diff-a97677ec20fc7af6c5600418cccf6a9c9e19313d63ad9da762db47989c1cdbbcR966-R971): Updated `ServerParam::addParams()` to include the new synchronization mode parameters with descriptions.
* [`src/serverparam.cpp`](diffhunk://#diff-a97677ec20fc7af6c5600418cccf6a9c9e19313d63ad9da762db47989c1cdbbcR1493-R1497): Updated `ServerParam::setDefaults()` to set default values for the new synchronization mode parameters.

### Server Parameter Class Updates:

* [`src/serverparam.h`](diffhunk://#diff-35acfab7075176d0bd4f7b6c8fce2d9230046e1012e876e08d57c02596599924R635-R638): Added member variables `M_max_synch_mode_cycle_duration_msec` and `M_max_allowed_missed_synch_mode_cycles` to the `ServerParam` class.
* [`src/serverparam.h`](diffhunk://#diff-35acfab7075176d0bd4f7b6c8fce2d9230046e1012e876e08d57c02596599924R1002-R1005): Added getter methods `maxSynchModeCycleDurationMsec()` and `maxAllowedMissedSynchModeCycles()` to the `ServerParam` class.

### Stadium Synchronization Logic:

* [`src/stadium.cpp`](diffhunk://#diff-0c84f439a5d0eaae0fe157498d72819ae09fe22c6b1cfbfa33cde32ab32ce0a2L2396-R2397): Updated `Stadium::doSendThink()` to use the new synchronization mode parameters from the `ServerParam` instance for controlling the maximum wait time and allowed missed cycles. [[1]](diffhunk://#diff-0c84f439a5d0eaae0fe157498d72819ae09fe22c6b1cfbfa33cde32ab32ce0a2L2396-R2397) [[2]](diffhunk://#diff-0c84f439a5d0eaae0fe157498d72819ae09fe22c6b1cfbfa33cde32ab32ce0a2R2516-R2517) [[3]](diffhunk://#diff-0c84f439a5d0eaae0fe157498d72819ae09fe22c6b1cfbfa33cde32ab32ce0a2L2527-R2536)

### Why these parameters are important?

Disabling the missed cycle checker functionality or increasing the length of synch mode cycles can be useful in training purposes.